### PR TITLE
No longer give pointer to OperationDeviceProxy in OnDeviceConnected callback

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -93,16 +93,15 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
         auto * exchangeMgr = device->GetExchangeManager();
         auto optionalSessionHandler = device->GetSecureSession();
         VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-        auto sessionHandle = optionalSessionHandler.Value();
         if (sSwitchOnOffState)
         {
             Clusters::OnOff::Commands::On::Type onCommand;
-            Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, onCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(exchangeMgr, optionalSessionHandler.Value(), binding.remote, onCommand, onSuccess, onFailure);
         }
         else
         {
             Clusters::OnOff::Commands::Off::Type offCommand;
-            Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, offCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(exchangeMgr, optionalSessionHandler.Value(), binding.remote, offCommand, onSuccess, onFailure);
         }
     }
 }

--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -67,7 +67,8 @@ static void RegisterSwitchCommands()
 }
 #endif // defined(ENABLE_CHIP_SHELL)
 
-static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::FoobarDeviceProxy * peer_device, void * context)
+static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::Messaging::ExchangeManager * exchangeMgr,
+                                      chip::SessionHandle * sessionHandle, void * context)
 {
     using namespace chip;
     using namespace chip::app;
@@ -88,17 +89,16 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
             ChipLogError(NotSpecified, "OnOff command failed: %" CHIP_ERROR_FORMAT, error.Format());
         };
 
+        VerifyOrDie(exchangeMgr != nullptr && sessionHandle != nullptr);
         if (sSwitchOnOffState)
         {
             Clusters::OnOff::Commands::On::Type onCommand;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
-                                             binding.remote, onCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(exchangeMgr, *sessionHandle, binding.remote, onCommand, onSuccess, onFailure);
         }
         else
         {
             Clusters::OnOff::Commands::Off::Type offCommand;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
-                                             binding.remote, offCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(exchangeMgr, *sessionHandle, binding.remote, offCommand, onSuccess, onFailure);
         }
     }
 }

--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -67,7 +67,7 @@ static void RegisterSwitchCommands()
 }
 #endif // defined(ENABLE_CHIP_SHELL)
 
-static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::DeviceProxy * peer_device, void * context)
+static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::FoobarDeviceProxy * peer_device, void * context)
 {
     using namespace chip;
     using namespace chip::app;

--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -91,9 +91,9 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
 
         VerifyOrDie(device != nullptr);
         auto * exchangeMgr = device->GetExchangeManager();
-        auto optionalSessionHandler = device->GetSecureSession()
+        auto optionalSessionHandler = device->GetSecureSession();
         VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-        auto sessionHandle = optionalSessionHandler.Value()
+        auto sessionHandle = optionalSessionHandler.Value();
         if (sSwitchOnOffState)
         {
             Clusters::OnOff::Commands::On::Type onCommand;

--- a/examples/all-clusters-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-app/esp32/main/include/ShellCommands.h
@@ -134,7 +134,7 @@ public:
 
 private:
     CASECommands() {}
-    static void OnConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+    static void OnConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
     {
         streamer_printf(streamer_get(), "Establish CASESession Success!\r\n");
         GetInstance().SetOnConnecting(false);

--- a/examples/all-clusters-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-app/esp32/main/include/ShellCommands.h
@@ -134,7 +134,7 @@ public:
 
 private:
     CASECommands() {}
-    static void OnConnected(void * context, OperationalDeviceProxy * deviceProxy)
+    static void OnConnected(void * context, FoobarDeviceProxy deviceProxy)
     {
         streamer_printf(streamer_get(), "Establish CASESession Success!\r\n");
         GetInstance().SetOnConnecting(false);

--- a/examples/all-clusters-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-app/esp32/main/include/ShellCommands.h
@@ -134,7 +134,7 @@ public:
 
 private:
     CASECommands() {}
-    static void OnConnected(void * context, FoobarDeviceProxy deviceProxy)
+    static void OnConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
     {
         streamer_printf(streamer_get(), "Establish CASESession Success!\r\n");
         GetInstance().SetOnConnecting(false);

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -95,9 +95,9 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
             Clusters::OnOff::Commands::Toggle::Type toggleCommand;
             VerifyOrDie(device != nullptr);
             auto * exchangeMgr = device->GetExchangeManager();
-            auto optionalSessionHandler = device->GetSecureSession()
+            auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-            auto sessionHandle = optionalSessionHandler.Value()
+            auto sessionHandle = optionalSessionHandler.Value();
             Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure);
         }
     }

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -68,7 +68,8 @@ static void RegisterSwitchCommands()
 }
 #endif // defined(ENABLE_CHIP_SHELL)
 
-static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::FoobarDeviceProxy * peer_device, void * context)
+static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
+                                      SessionHandle * sessionHandle, void * context)
 {
     using namespace chip;
     using namespace chip::app;
@@ -92,8 +93,8 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
         // command (SwitchCommandHandler)
         {
             Clusters::OnOff::Commands::Toggle::Type toggleCommand;
-            Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(),
-                                             binding.remote, toggleCommand, onSuccess, onFailure);
+            VerifyOrDie(exchangeMgr != nullptr && sessionHandle != nullptr);
+            Controller::InvokeCommandRequest(exchangeMgr, *sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure);
         }
     }
 }

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -96,6 +96,8 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
             VerifyOrDie(device != nullptr);
             auto * exchangeMgr = device->GetExchangeManager();
             auto optionalSessionHandler = device->GetSecureSession();
+            // TODO, could probably get away with doing VerifyOrDie(device->ConnectionReady());, then just using it directly.
+            // This would be done in all spots where I am doing something similar.
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
             Controller::InvokeCommandRequest(exchangeMgr, optionalSessionHandler.Value(), binding.remote, toggleCommand, onSuccess, onFailure);
         }

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -68,7 +68,7 @@ static void RegisterSwitchCommands()
 }
 #endif // defined(ENABLE_CHIP_SHELL)
 
-static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::DeviceProxy * peer_device, void * context)
+static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::FoobarDeviceProxy * peer_device, void * context)
 {
     using namespace chip;
     using namespace chip::app;

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -68,8 +68,8 @@ static void RegisterSwitchCommands()
 }
 #endif // defined(ENABLE_CHIP_SHELL)
 
-static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
-                                      SessionHandle * sessionHandle, void * context)
+static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::Messaging::ExchangeManager * exchangeMgr,
+                                      chip::SessionHandle * sessionHandle, void * context)
 {
     using namespace chip;
     using namespace chip::app;

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -68,8 +68,8 @@ static void RegisterSwitchCommands()
 }
 #endif // defined(ENABLE_CHIP_SHELL)
 
-static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::Messaging::ExchangeManager * exchangeMgr,
-                                      chip::SessionHandle * sessionHandle, void * context)
+static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, chip::DeviceProxySession * device,
+                                      void * context)
 {
     using namespace chip;
     using namespace chip::app;
@@ -93,8 +93,12 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
         // command (SwitchCommandHandler)
         {
             Clusters::OnOff::Commands::Toggle::Type toggleCommand;
-            VerifyOrDie(exchangeMgr != nullptr && sessionHandle != nullptr);
-            Controller::InvokeCommandRequest(exchangeMgr, *sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure);
+            VerifyOrDie(device != nullptr);
+            auto * exchangeMgr = device->GetExchangeManager();
+            auto optionalSessionHandler = device->GetSecureSession()
+            VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
+            auto sessionHandle = optionalSessionHandler.Value()
+            Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure);
         }
     }
 }

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -97,8 +97,7 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
             auto * exchangeMgr = device->GetExchangeManager();
             auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-            auto sessionHandle = optionalSessionHandler.Value();
-            Controller::InvokeCommandRequest(exchangeMgr, sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure);
+            Controller::InvokeCommandRequest(exchangeMgr, optionalSessionHandler.Value(), binding.remote, toggleCommand, onSuccess, onFailure);
         }
     }
 }

--- a/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
@@ -134,7 +134,7 @@ public:
 
 private:
     CASECommands() {}
-    static void OnConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+    static void OnConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
     {
         streamer_printf(streamer_get(), "Establish CASESession Success!\r\n");
         GetInstance().SetOnConnecting(false);

--- a/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
@@ -134,7 +134,7 @@ public:
 
 private:
     CASECommands() {}
-    static void OnConnected(void * context, OperationalDeviceProxy * deviceProxy)
+    static void OnConnected(void * context, FoobarDeviceProxy deviceProxy)
     {
         streamer_printf(streamer_get(), "Establish CASESession Success!\r\n");
         GetInstance().SetOnConnecting(false);

--- a/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
@@ -134,7 +134,7 @@ public:
 
 private:
     CASECommands() {}
-    static void OnConnected(void * context, FoobarDeviceProxy deviceProxy)
+    static void OnConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
     {
         streamer_printf(streamer_get(), "Establish CASESession Success!\r\n");
         GetInstance().SetOnConnecting(false);

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -46,14 +46,14 @@ CHIP_ERROR ModelCommand::RunCommand()
                                                     &mOnDeviceConnectionFailureCallback);
 }
 
-void ModelCommand::OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+void ModelCommand::OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                        chip::SessionHandle & sessionHandle)
 {
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
     // TODO TMsg I have no clue where this one goes to. Not sure if DeviceProxySession being on the stack is ok.
-    chip::DeviceProxySession device(exchangeMgr, sessionHandle);
+    chip::DeviceProxySession device(&exchangeMgr, sessionHandle);
     CHIP_ERROR err = command->SendCommand(&device, command->mEndPointId);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -46,12 +46,14 @@ CHIP_ERROR ModelCommand::RunCommand()
                                                     &mOnDeviceConnectionFailureCallback);
 }
 
-void ModelCommand::OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device)
+void ModelCommand::OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+                                       chip::SessionHandle & sessionHandle)
 {
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
-    // TODO TMsg I have no clue where this one goes to. Not sure if FoobarDeviceProxy being on the stack is ok.
+    // TODO TMsg I have no clue where this one goes to. Not sure if DeviceProxySession being on the stack is ok.
+    chip::DeviceProxySession device(exchangeMgr, sessionHandle);
     CHIP_ERROR err = command->SendCommand(&device, command->mEndPointId);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -52,7 +52,6 @@ void ModelCommand::OnDeviceConnectedFn(void * context, chip::Messaging::Exchange
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
-    // TODO TMsg I have no clue where this one goes to. Not sure if DeviceProxySession being on the stack is ok.
     chip::DeviceProxySession device(&exchangeMgr, sessionHandle);
     CHIP_ERROR err = command->SendCommand(&device, command->mEndPointId);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -46,12 +46,13 @@ CHIP_ERROR ModelCommand::RunCommand()
                                                     &mOnDeviceConnectionFailureCallback);
 }
 
-void ModelCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)
+void ModelCommand::OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device)
 {
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
-    CHIP_ERROR err = command->SendCommand(device, command->mEndPointId);
+    // TODO TMsg I have no clue where this one goes to. Not sure if FoobarDeviceProxy being on the stack is ok.
+    CHIP_ERROR err = command->SendCommand(&device, command->mEndPointId);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -69,7 +69,8 @@ private:
     chip::NodeId mDestinationId;
     std::vector<chip::EndpointId> mEndPointId;
 
-    static void OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device);
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+                                    chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -69,7 +69,7 @@ private:
     chip::NodeId mDestinationId;
     std::vector<chip::EndpointId> mEndPointId;
 
-    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                     chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -69,7 +69,7 @@ private:
     chip::NodeId mDestinationId;
     std::vector<chip::EndpointId> mEndPointId;
 
-    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
+    static void OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
@@ -69,12 +69,12 @@ CHIP_ERROR CloseSessionCommand::CloseSession(DeviceProxy * device)
     return err;
 }
 
-void CloseSessionCommand::OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device)
+void CloseSessionCommand::OnDeviceConnectedFn(void * context, FoobarDeviceProxy device)
 {
     auto * command = reinterpret_cast<CloseSessionCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
-    CHIP_ERROR err = command->CloseSession(device);
+    CHIP_ERROR err = command->CloseSession(&device);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }
 

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
@@ -69,13 +69,13 @@ CHIP_ERROR CloseSessionCommand::CloseSession(DeviceProxy * device)
     return err;
 }
 
-void CloseSessionCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager * exchangeMgr,
+void CloseSessionCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr,
                                               SessionHandle & sessionHandle)
 {
     auto * command = reinterpret_cast<CloseSessionCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
-    DeviceProxySession device(exchangeMgr, sessionHandle);
+    DeviceProxySession device(&exchangeMgr, sessionHandle);
     CHIP_ERROR err = command->CloseSession(&device);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
@@ -69,11 +69,13 @@ CHIP_ERROR CloseSessionCommand::CloseSession(DeviceProxy * device)
     return err;
 }
 
-void CloseSessionCommand::OnDeviceConnectedFn(void * context, FoobarDeviceProxy device)
+void CloseSessionCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager * exchangeMgr,
+                                              SessionHandle & sessionHandle)
 {
     auto * command = reinterpret_cast<CloseSessionCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
+    DeviceProxySession device(exchangeMgr, sessionHandle);
     CHIP_ERROR err = command->CloseSession(&device);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.h
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.h
@@ -46,7 +46,7 @@ private:
     chip::NodeId mDestinationId;
     chip::Optional<uint16_t> mTimeoutSecs;
 
-    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
+    static void OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     // Try to send the action CloseSession status report.

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.h
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.h
@@ -46,7 +46,7 @@ private:
     chip::NodeId mDestinationId;
     chip::Optional<uint16_t> mTimeoutSecs;
 
-    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                     chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.h
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.h
@@ -46,7 +46,8 @@ private:
     chip::NodeId mDestinationId;
     chip::Optional<uint16_t> mTimeoutSecs;
 
-    static void OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device);
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+                                    chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     // Try to send the action CloseSession status report.

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -48,13 +48,13 @@ CHIP_ERROR TestCommand::WaitForCommissionee(const char * identity,
                                                         &mOnDeviceConnectionFailureCallback);
 }
 
-void TestCommand::OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+void TestCommand::OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                       chip::SessionHandle & sessionHandle)
 {
     ChipLogProgress(chipTool, " **** Test Setup: Device Connected\n");
     auto * command = static_cast<TestCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Device connected, but cannot run the test, as the context is null"));
-    command->mDevices[command->GetIdentity()] = chip::DeviceProxySession(exchangeMgr, sessionHandle);
+    command->mDevices[command->GetIdentity()] = chip::DeviceProxySession(&exchangeMgr, sessionHandle);
 
     LogErrorOnFailure(command->ContinueOnChipMainThread(CHIP_NO_ERROR));
 }

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR TestCommand::WaitForCommissionee(const char * identity,
                                                         &mOnDeviceConnectionFailureCallback);
 }
 
-void TestCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)
+void TestCommand::OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device)
 {
     ChipLogProgress(chipTool, " **** Test Setup: Device Connected\n");
     auto * command = static_cast<TestCommand *>(context);

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -48,12 +48,13 @@ CHIP_ERROR TestCommand::WaitForCommissionee(const char * identity,
                                                         &mOnDeviceConnectionFailureCallback);
 }
 
-void TestCommand::OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device)
+void TestCommand::OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+                                      chip::SessionHandle & sessionHandle)
 {
     ChipLogProgress(chipTool, " **** Test Setup: Device Connected\n");
     auto * command = static_cast<TestCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "Device connected, but cannot run the test, as the context is null"));
-    command->mDevices[command->GetIdentity()] = device;
+    command->mDevices[command->GetIdentity()] = chip::DeviceProxySession(exchangeMgr, sessionHandle);
 
     LogErrorOnFailure(command->ContinueOnChipMainThread(CHIP_NO_ERROR));
 }

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -68,7 +68,7 @@ protected:
     chip::DeviceProxy * GetDevice(const char * identity) override { return &mDevices[identity]; }
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override{};
 
-    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
                                     chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -68,7 +68,8 @@ protected:
     chip::DeviceProxy * GetDevice(const char * identity) override { return &mDevices[identity]; }
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override{};
 
-    static void OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device);
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager * exchangeMgr,
+                                    chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override;
@@ -92,7 +93,7 @@ protected:
 
     chip::Optional<char *> mPICSFilePath;
     chip::Optional<uint16_t> mTimeout;
-    std::map<std::string, chip::FoobarDeviceProxy> mDevices;
+    std::map<std::string, chip::DeviceProxySession> mDevices;
 
     // When set to false, prevents interaction model events from affecting the current test status.
     // This flag exists because if an error happens while processing a response the allocated

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -65,10 +65,10 @@ protected:
     void OnWaitForMs() override { NextTest(); };
 
     /////////// Interaction Model Interface /////////
-    chip::DeviceProxy * GetDevice(const char * identity) override { return mDevices[identity]; }
+    chip::DeviceProxy * GetDevice(const char * identity) override { return &mDevices[identity]; }
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override{};
 
-    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
+    static void OnDeviceConnectedFn(void * context, chip::FoobarDeviceProxy device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override;
@@ -92,7 +92,7 @@ protected:
 
     chip::Optional<char *> mPICSFilePath;
     chip::Optional<uint16_t> mTimeout;
-    std::map<std::string, chip::DeviceProxy *> mDevices;
+    std::map<std::string, chip::FoobarDeviceProxy> mDevices;
 
     // When set to false, prevents interaction model events from affecting the current test status.
     // This flag exists because if an error happens while processing a response the allocated

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -52,7 +52,7 @@ Engine sShellSwitchBindingSubCommands;
 namespace {
 
 void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
-                                       Messaging::ExchangeManager * exchangeMgr, SessionHandle * sessionHandle)
+                                       Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -62,7 +62,6 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
         ChipLogError(NotSpecified, "OnOff command failed: %" CHIP_ERROR_FORMAT, error.Format());
     };
 
-    VerifyOrDie(exchangeMgr != nullptr && sessionHandle != nullptr);
     switch (commandId)
     {
     case Clusters::OnOff::Commands::Toggle::Id:
@@ -126,7 +125,8 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Messaging
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
+            VerifyOrDie(exchangeMgr != nullptr && sessionHandle != nullptr);
+            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, *sessionHandle);
             break;
         }
     }

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -51,7 +51,7 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, DeviceProxy * peer_device)
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -107,7 +107,7 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -105,8 +105,7 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
-                               SessionHandle * sessionHandle, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxySession * device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
@@ -125,8 +124,12 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Messaging
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:
-            VerifyOrDie(exchangeMgr != nullptr && sessionHandle != nullptr);
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, *sessionHandle);
+            VerifyOrDie(device != nullptr);
+            auto * exchangeMgr = device->GetExchangeManager();
+            auto optionalSessionHandler = device->GetSecureSession()
+            VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
+            auto sessionHandle = optionalSessionHandler.Value()
+            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
             break;
         }
     }

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -51,7 +51,8 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device)
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+                                       DeviceProxySession * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -107,7 +108,8 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
+                               SessionHandle & sessionHandle, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
@@ -126,6 +128,8 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDev
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:
+            // TODO remove this DeviceProxySession and pass in data directly
+            DeviceProxySession peer_device(exchangeMgr, sessionHandle);
             ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device);
             break;
         }

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -126,9 +126,9 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
         case Clusters::OnOff::Id:
             VerifyOrDie(device != nullptr);
             auto * exchangeMgr = device->GetExchangeManager();
-            auto optionalSessionHandler = device->GetSecureSession()
+            auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-            auto sessionHandle = optionalSessionHandler.Value()
+            auto sessionHandle = optionalSessionHandler.Value();
             ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
             break;
         }

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -128,8 +128,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
             auto * exchangeMgr = device->GetExchangeManager();
             auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-            auto sessionHandle = optionalSessionHandler.Value();
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
+            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, optionalSessionHandler.Value());
             break;
         }
     }

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -50,7 +50,8 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device)
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding,
+                                       Messaging::ExchangeManager * exchangeMgr, SessionHandle * sessionHandle)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -60,24 +61,22 @@ void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTa
         ChipLogError(NotSpecified, "OnOff command failed: %" CHIP_ERROR_FORMAT, error.Format());
     };
 
+    VerifyOrDie(exchangeMgr != nullptr && sessiongHandle != nullptr);
     switch (commandId)
     {
     case Clusters::OnOff::Commands::Toggle::Id:
         Clusters::OnOff::Commands::Toggle::Type toggleCommand;
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         toggleCommand, onSuccess, onFailure);
+        Controller::InvokeCommandRequest(exchangeMgr, *sessionHandle, binding.remote, toggleCommand, onSuccess, onFailure);
         break;
 
     case Clusters::OnOff::Commands::On::Id:
         Clusters::OnOff::Commands::On::Type onCommand;
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         onCommand, onSuccess, onFailure);
+        Controller::InvokeCommandRequest(exchangeMgr, *sessionHandle, binding.remote, onCommand, onSuccess, onFailure);
         break;
 
     case Clusters::OnOff::Commands::Off::Id:
         Clusters::OnOff::Commands::Off::Type offCommand;
-        Controller::InvokeCommandRequest(peer_device->GetExchangeManager(), peer_device->GetSecureSession().Value(), binding.remote,
-                                         offCommand, onSuccess, onFailure);
+        Controller::InvokeCommandRequest(exchangeMgr, *sessionHandle, binding.remote, offCommand, onSuccess, onFailure);
         break;
     }
 }
@@ -106,7 +105,8 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
+                               SessionHandle * sessionHandle, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
@@ -125,7 +125,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDev
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device);
+            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
             break;
         }
     }

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -50,7 +50,7 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, DeviceProxy * peer_device)
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -106,7 +106,7 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -127,8 +127,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
             auto * exchangeMgr = device->GetExchangeManager();
             auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-            auto sessionHandle = optionalSessionHandler.Value();
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
+            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, optionalSessionHandler.Value());
             break;
         }
     }

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -125,9 +125,9 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
         case Clusters::OnOff::Id:
             VerifyOrDie(device != nullptr);
             auto * exchangeMgr = device->GetExchangeManager();
-            auto optionalSessionHandler = device->GetSecureSession()
+            auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-            auto sessionHandle = optionalSessionHandler.Value()
+            auto sessionHandle = optionalSessionHandler.Value();
             ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
             break;
         }

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -78,7 +78,7 @@ void BindingHandler::OnInvokeCommandFailure(bool aEarlyExit, BindingData & aBind
 }
 
 void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
-                                         Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle, void * aContext)
+                                         Messaging::ExchangeManager * exchangeMgr, SessionHandle * sessionHandle, void * aContext)
 {
     CHIP_ERROR ret     = CHIP_NO_ERROR;
     BindingData * data = reinterpret_cast<BindingData *>(aContext);

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -100,7 +100,7 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
         // We are validating we can get exchange manager and session handle from device
         // before we blindly grab them for each InvokeCommandRequest below
         auto * exchangeMgr = device->GetExchangeManager();
-        auto optionalSessionHandler = device->GetSecureSession()
+        auto optionalSessionHandler = device->GetSecureSession();
         VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
     }
 
@@ -183,7 +183,7 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
         // We are validating we can get exchange manager and session handle from device
         // before we blindly grab them for each InvokeCommandRequest below
         auto * exchangeMgr = device->GetExchangeManager();
-        auto optionalSessionHandler = device->GetSecureSession()
+        auto optionalSessionHandler = device->GetSecureSession();
         VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
     }
 

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -35,18 +35,24 @@ void BindingHandler::Init()
     DeviceLayer::PlatformMgr().ScheduleWork(InitInternal);
 }
 
-void BindingHandler::OnInvokeCommandFailure(DeviceProxy * aDevice, BindingData & aBindingData, CHIP_ERROR aError)
+//void BindingHandler::OnInvokeCommandFailure(DeviceProxy * aDevice, BindingData & aBindingData, CHIP_ERROR aError)
+void BindingHandler::OnInvokeCommandFailure(bool aEarlyExit, BindingData & aBindingData, CHIP_ERROR aError)
 {
     CHIP_ERROR error;
 
     if (aError == CHIP_ERROR_TIMEOUT && !BindingHandler::GetInstance().mCaseSessionRecovered)
     {
         LOG_INF("Response timeout for invoked command, trying to recover CASE session.");
+#if 0
         if (!aDevice)
             return;
 
         // Release current CASE session.
         aDevice->Disconnect();
+#else
+        if (aEarlyExit)
+            return;
+#endif
 
         // Set flag to not try recover session multiple times.
         BindingHandler::GetInstance().mCaseSessionRecovered = true;
@@ -71,7 +77,7 @@ void BindingHandler::OnInvokeCommandFailure(DeviceProxy * aDevice, BindingData &
     }
 }
 
-void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding, DeviceProxy * aDevice,
+void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding, FoobarDeviceProxy * aDevice,
                                          void * aContext)
 {
     CHIP_ERROR ret     = CHIP_NO_ERROR;
@@ -85,8 +91,9 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
             BindingHandler::GetInstance().mCaseSessionRecovered = false;
     };
 
-    auto onFailure = [aDevice, dataRef = *data](CHIP_ERROR aError) mutable {
-        BindingHandler::OnInvokeCommandFailure(aDevice, dataRef, aError);
+    bool earlyExit = aDevice == nullptr;
+    auto onFailure = [earlyExit, dataRef = *data](CHIP_ERROR aError) mutable {
+        BindingHandler::OnInvokeCommandFailure(earlyExit, dataRef, aError);
     };
 
     switch (aCommandId)
@@ -144,7 +151,7 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
 }
 
 void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const EmberBindingTableEntry & aBinding,
-                                                DeviceProxy * aDevice, void * aContext)
+                                                FoobarDeviceProxy * aDevice, void * aContext)
 {
     BindingData * data = reinterpret_cast<BindingData *>(aContext);
 
@@ -156,8 +163,9 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
             BindingHandler::GetInstance().mCaseSessionRecovered = false;
     };
 
-    auto onFailure = [aDevice, dataRef = *data](CHIP_ERROR aError) mutable {
-        BindingHandler::OnInvokeCommandFailure(aDevice, dataRef, aError);
+    bool earlyExit = aDevice == nullptr;
+    auto onFailure = [earlyExit, dataRef = *data](CHIP_ERROR aError) mutable {
+        BindingHandler::OnInvokeCommandFailure(earlyExit, dataRef, aError);
     };
 
     CHIP_ERROR ret = CHIP_NO_ERROR;
@@ -189,7 +197,7 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
     }
 }
 
-void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxy * deviceProxy, void * context)
+void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDeviceProxy * deviceProxy, void * context)
 {
     VerifyOrReturn(context != nullptr, LOG_ERR("Invalid context for Light switch handler"););
     BindingData * data = static_cast<BindingData *>(context);

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -105,8 +105,8 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
-                               SessionHandle * sessionHandle, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxySession * device,
+                               void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);
@@ -126,8 +126,12 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Messaging
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:
-            VerifyOrDie(exchangeMgr != nullptr && sessionHandle != nullptr);
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, *sessionHandle);
+            VerifyOrDie(device != nullptr);
+            auto * exchangeMgr = device->GetExchangeManager();
+            auto optionalSessionHandler = device->GetSecureSession()
+            VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
+            auto sessionHandle = optionalSessionHandler.Value()
+            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
             break;
         }
     }

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -130,8 +130,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
             auto * exchangeMgr = device->GetExchangeManager();
             auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
-            auto sessionHandle = optionalSessionHandler.Value()
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);
+            ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, optionalSessionHandler.Value());
             break;
         }
     }

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -51,7 +51,7 @@ Engine sShellSwitchBindingSubCommands;
 
 namespace {
 
-void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, DeviceProxy * peer_device)
+void ProcessOnOffUnicastBindingCommand(CommandId commandId, const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device)
 {
     auto onSuccess = [](const ConcreteCommandPath & commandPath, const StatusIB & status, const auto & dataResponse) {
         ChipLogProgress(NotSpecified, "OnOff command succeeds");
@@ -107,7 +107,7 @@ void ProcessOnOffGroupBindingCommand(CommandId commandId, const EmberBindingTabl
     }
 }
 
-void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context)
+void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device, void * context)
 {
     VerifyOrReturn(context != nullptr, ChipLogError(NotSpecified, "OnDeviceConnectedFn: context is null"));
     BindingCommandData * data = static_cast<BindingCommandData *>(context);

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -128,7 +128,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, DevicePro
         case Clusters::OnOff::Id:
             VerifyOrDie(device != nullptr);
             auto * exchangeMgr = device->GetExchangeManager();
-            auto optionalSessionHandler = device->GetSecureSession()
+            auto optionalSessionHandler = device->GetSecureSession();
             VerifyOrDie(exchangeMgr != nullptr && optionalSessionHandler.HasValue());
             auto sessionHandle = optionalSessionHandler.Value()
             ProcessOnOffUnicastBindingCommand(data->commandId, binding, exchangeMgr, sessionHandle);

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -233,7 +233,8 @@ public:
 
 private:
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
-    static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
+    static void OnDeviceConnectedFn(void * context, chip::Messaging::ExchangeManager & exchangeMgr,
+                                    chip::SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
@@ -308,20 +309,10 @@ void PairingCommand::OnCommissioningComplete(NodeId nodeId, CHIP_ERROR err)
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
-void PairingCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)
+void PairingCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     ChipLogProgress(Controller, "OnDeviceConnectedFn");
     CommissionerDiscoveryController * cdc = GetCommissionerDiscoveryController();
-
-    if (device == nullptr)
-    {
-        ChipLogProgress(AppServer, "No OperationalDeviceProxy returned from OnDeviceConnectedFn");
-        if (cdc != nullptr)
-        {
-            cdc->CommissioningFailed(CHIP_ERROR_INCORRECT_STATE);
-        }
-        return;
-    }
 
     if (cdc != nullptr)
     {
@@ -329,7 +320,8 @@ void PairingCommand::OnDeviceConnectedFn(void * context, chip::OperationalDevice
         uint16_t productId = gAutoCommissioner.GetCommissioningParameters().GetRemoteProductId().Value();
         ChipLogProgress(Support, " ----- AutoCommissioner -- Commissionee vendorId=0x%04X productId=0x%04X", vendorId, productId);
 
-        cdc->CommissioningSucceeded(vendorId, productId, gRemoteId, device);
+        // TODO Need to figure out what I need to do here
+        cdc->CommissioningSucceeded(vendorId, productId, gRemoteId, exchangeMgr, sessionHandle);
     }
 }
 

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -320,7 +320,6 @@ void PairingCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeMana
         uint16_t productId = gAutoCommissioner.GetCommissioningParameters().GetRemoteProductId().Value();
         ChipLogProgress(Support, " ----- AutoCommissioner -- Commissionee vendorId=0x%04X productId=0x%04X", vendorId, productId);
 
-        // TODO Need to figure out what I need to do here
         cdc->CommissioningSucceeded(vendorId, productId, gRemoteId, exchangeMgr, sessionHandle);
     }
 }

--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -60,11 +60,12 @@ MyPincodeService gMyPincodeService;
 
 class MyPostCommissioningListener : public PostCommissioningListener
 {
-    void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, OperationalDeviceProxy * device) override
+    void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, Messaging::ExchangeManager & exchangeMgr,
+                                SessionHandle & sessionHandle) override
     {
 
-        ContentAppPlatform::GetInstance().ManageClientAccess(device, vendorId, GetDeviceCommissioner()->GetNodeId(),
-                                                             OnSuccessResponse, OnFailureResponse);
+        ContentAppPlatform::GetInstance().ManageClientAccess(
+            exchangeMgr, sessionHandle, vendorId, GetDeviceCommissioner()->GetNodeId(), OnSuccessResponse, OnFailureResponse);
     }
 
     /* Callback when command results in success */

--- a/examples/tv-app/linux/AppImpl.cpp
+++ b/examples/tv-app/linux/AppImpl.cpp
@@ -86,11 +86,12 @@ MyPincodeService gMyPincodeService;
 
 class MyPostCommissioningListener : public PostCommissioningListener
 {
-    void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, OperationalDeviceProxy * device) override
+    void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, Messaging::ExchangeManager & exchangeMgr,
+                                SessionHandle & sessionHandle) override
     {
 
-        ContentAppPlatform::GetInstance().ManageClientAccess(device, vendorId, GetDeviceCommissioner()->GetNodeId(),
-                                                             OnSuccessResponse, OnFailureResponse);
+        ContentAppPlatform::GetInstance().ManageClientAccess(
+            exchangeMgr, sessionHandle, vendorId, GetDeviceCommissioner()->GetNodeId(), OnSuccessResponse, OnFailureResponse);
     }
 
     /* Callback when command results in success */

--- a/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
+++ b/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
@@ -61,13 +61,15 @@ CHIP_ERROR ModelCommand::RunCommand()
     return CHIP_NO_ERROR;
 }
 
-void ModelCommand::OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device)
+void ModelCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     ChipLogProgress(chipTool, "ModelCommand::OnDeviceConnectedFn");
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
-    CHIP_ERROR err = command->SendCommand(device, command->mEndPointId);
+    // TODO figure out if this can actaully live on the stack, if so we likely can make changes all the way through
+    DeviceProxySession device(&exchangeMgr, sessionHandle);
+    CHIP_ERROR err = command->SendCommand(&device, command->mEndPointId);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }
 

--- a/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
+++ b/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
@@ -67,7 +67,6 @@ void ModelCommand::OnDeviceConnectedFn(void * context, Messaging::ExchangeManage
     ModelCommand * command = reinterpret_cast<ModelCommand *>(context);
     VerifyOrReturn(command != nullptr, ChipLogError(chipTool, "OnDeviceConnectedFn: context is null"));
 
-    // TODO figure out if this can actaully live on the stack, if so we likely can make changes all the way through
     DeviceProxySession device(&exchangeMgr, sessionHandle);
     CHIP_ERROR err = command->SendCommand(&device, command->mEndPointId);
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -48,7 +48,7 @@ private:
         _this->foobar                  = chip::DeviceProxySession(&exchangeMgr, sessionHandle);
         _this->mOperationalDeviceProxy = &_this->foobar;
         _this->mInitialized            = true;
-        ChipLogProgress(AppServer, "HandleDeviceConnected created an instance of OperationalDeviceProxy");
+        ChipLogProgress(AppServer, "HandleDeviceConnected created an instance of DeviceProxySession");
     }
 
     static void HandleDeviceConnectionFailure(void * context, chip::PeerId peerId, CHIP_ERROR error)

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -32,9 +32,9 @@ public:
     bool IsInitialized() { return mInitialized; }
     chip::NodeId GetNodeId() const { return mNodeId; }
     chip::FabricIndex GetFabricIndex() const { return mFabricIndex; }
-    chip::DeviceProxySession * GetDeviceProxy() const
+    const chip::DeviceProxySession * GetDeviceProxy() const
     {
-        if mDeviceProxy.ConnectionReady()
+        if (mDeviceProxy.ConnectionReady())
         {
             return &mDeviceProxy;
         }
@@ -59,7 +59,7 @@ private:
     static void HandleDeviceConnectionFailure(void * context, chip::PeerId peerId, CHIP_ERROR error)
     {
         TargetVideoPlayerInfo * _this  = static_cast<TargetVideoPlayerInfo *>(context);
-        _this->mDeviceProxy = DeviceProxySession();
+        _this->mDeviceProxy = chip::DeviceProxySession();
     }
 
     static constexpr size_t kMaxNumberOfEndpoints = 5;

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -32,7 +32,8 @@ public:
     bool IsInitialized() { return mInitialized; }
     chip::NodeId GetNodeId() const { return mNodeId; }
     chip::FabricIndex GetFabricIndex() const { return mFabricIndex; }
-    chip::OperationalDeviceProxy * GetOperationalDeviceProxy() const { return mOperationalDeviceProxy; }
+    // TODO consider renaming GetOperationalDeviceProxy
+    chip::DeviceProxySession * GetOperationalDeviceProxy() const { return mOperationalDeviceProxy; }
 
     CHIP_ERROR Initialize(chip::NodeId nodeId, chip::FabricIndex fabricIndex);
     TargetEndpointInfo * GetOrAddEndpoint(chip::EndpointId endpointId);
@@ -41,10 +42,11 @@ public:
     void PrintInfo();
 
 private:
-    static void HandleDeviceConnected(void * context, chip::OperationalDeviceProxy * device)
+    static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
     {
         TargetVideoPlayerInfo * _this  = static_cast<TargetVideoPlayerInfo *>(context);
-        _this->mOperationalDeviceProxy = device;
+        foobar                         = chip::DeviceProxySession(&exchangeMgr, sessionHandle);
+        _this->mOperationalDeviceProxy = &foobar;
         _this->mInitialized            = true;
         ChipLogProgress(AppServer, "HandleDeviceConnected created an instance of OperationalDeviceProxy");
     }
@@ -55,11 +57,13 @@ private:
         _this->mOperationalDeviceProxy = nullptr;
     }
 
+    // TODO can we allocate this as a unique pointer?
+    static chip::DeviceProxySession foobar;
     static constexpr size_t kMaxNumberOfEndpoints = 5;
     TargetEndpointInfo mEndpoints[kMaxNumberOfEndpoints];
     chip::NodeId mNodeId;
     chip::FabricIndex mFabricIndex;
-    chip::OperationalDeviceProxy * mOperationalDeviceProxy;
+    chip::DeviceProxySession * mOperationalDeviceProxy = nullptr;
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnConnectionFailureCallback;

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -42,11 +42,11 @@ public:
     void PrintInfo();
 
 private:
-    static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
+    static void HandleDeviceConnected(void * context, chip::Messaging::ExchangeManager & exchangeMgr, chip::SessionHandle & sessionHandle)
     {
         TargetVideoPlayerInfo * _this  = static_cast<TargetVideoPlayerInfo *>(context);
-        foobar                         = chip::DeviceProxySession(&exchangeMgr, sessionHandle);
-        _this->mOperationalDeviceProxy = &foobar;
+        _this->foobar                  = chip::DeviceProxySession(&exchangeMgr, sessionHandle);
+        _this->mOperationalDeviceProxy = &_this->foobar;
         _this->mInitialized            = true;
         ChipLogProgress(AppServer, "HandleDeviceConnected created an instance of OperationalDeviceProxy");
     }
@@ -57,12 +57,12 @@ private:
         _this->mOperationalDeviceProxy = nullptr;
     }
 
-    // TODO can we allocate this as a unique pointer?
-    static chip::DeviceProxySession foobar;
     static constexpr size_t kMaxNumberOfEndpoints = 5;
     TargetEndpointInfo mEndpoints[kMaxNumberOfEndpoints];
     chip::NodeId mNodeId;
     chip::FabricIndex mFabricIndex;
+    // TODO temp hack, can we allocate this as a unique pointer. If it has to be statically allocated where should we do it?
+    chip::DeviceProxySession foobar;
     chip::DeviceProxySession * mOperationalDeviceProxy = nullptr;
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnConnectedCallback;

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -199,7 +199,7 @@ CHIP_ERROR CastingServer::ContentLauncherLaunchURL(const char * contentUrl, cons
     if (optionalSessionHandle.HasValue())
     {
         ChipLogError(AppServer, "Session Handle has expired");
-        return;
+        return CHIP_ERROR_PEER_NODE_NOT_FOUND;
     }
 
     ContentLauncherCluster cluster(*operationalDeviceProxy->GetExchangeManager(), optionalSessionHandle.Value(), kTvEndpoint);

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -134,7 +134,7 @@ void CastingServer::ReadServerClustersForNode(NodeId nodeId)
 
 void CastingServer::ReadServerClusters(EndpointId endpointId)
 {
-    DeviceProxySession * deviceProxy = mTargetVideoPlayerInfo.GetDeviceProxy();
+    const DeviceProxySession * deviceProxy = mTargetVideoPlayerInfo.GetDeviceProxy();
     if (deviceProxy == nullptr)
     {
         ChipLogError(AppServer, "Failed in getting an instance of DeviceProxy");
@@ -182,7 +182,7 @@ void CastingServer::OnDescriptorReadFailureResponse(void * context, CHIP_ERROR e
 CHIP_ERROR CastingServer::ContentLauncherLaunchURL(const char * contentUrl, const char * contentDisplayStr,
                                                    std::function<void(CHIP_ERROR)> launchURLResponseCallback)
 {
-    DeviceProxySession * deviceProxy = mTargetVideoPlayerInfo.GetDeviceProxy();
+    const DeviceProxySession * deviceProxy = mTargetVideoPlayerInfo.GetDeviceProxy();
     if (deviceProxy == nullptr)
     {
         ChipLogError(AppServer, "Failed in getting an instance of DeviceProxy");

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -44,12 +44,12 @@ CHIP_ERROR TargetVideoPlayerInfo::Initialize(NodeId nodeId, FabricIndex fabricIn
 
     server->GetCASESessionManager()->FindOrEstablishSession(peerID, &mOnConnectedCallback, &mOnConnectionFailureCallback);
 
-    if (mOperationalDeviceProxy == nullptr)
+    if (mDeviceProxy.ConnectionReady())
     {
         ChipLogError(AppServer, "Failed to find an existing instance of OperationalDeviceProxy to the peer");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
-    ChipLogProgress(AppServer, "Created an instance of OperationalDeviceProxy");
+    ChipLogProgress(AppServer, "Created an instance of DeviceProxy");
 
     mInitialized = true;
     return CHIP_NO_ERROR;

--- a/scripts/idl/generators/java/ChipClustersCpp.jinja
+++ b/scripts/idl/generators/java/ChipClustersCpp.jinja
@@ -116,8 +116,8 @@ JNI_METHOD(jlong, {{cluster.name | capitalcase}}Cluster, initWithDevice)(JNIEnv 
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
     if (device->GetSecureSession().HasValue())
     {
-      {{cluster.name |  capitalcase}}Cluster * cppCluster = new {{cluster.name | capitalcase}}Cluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-      return reinterpret_cast<jlong>(cppCluster);
+        {{cluster.name |  capitalcase}}Cluster * cppCluster = new {{cluster.name | capitalcase}}Cluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
     }
     return reinterpret_cast<jlong>(nullptr);
 }

--- a/scripts/idl/generators/java/ChipClustersCpp.jinja
+++ b/scripts/idl/generators/java/ChipClustersCpp.jinja
@@ -114,8 +114,12 @@ JNI_METHOD(jlong, {{cluster.name | capitalcase}}Cluster, initWithDevice)(JNIEnv 
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    {{cluster.name |  capitalcase}}Cluster * cppCluster = new {{cluster.name | capitalcase}}Cluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+      {{cluster.name |  capitalcase}}Cluster * cppCluster = new {{cluster.name | capitalcase}}Cluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+      return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 {% for command in cluster.commands -%}

--- a/scripts/idl/tests/outputs/cluster_struct_attribute/jni/DemoClusterClient-InvokeSubscribeImpl.cpp
+++ b/scripts/idl/tests/outputs/cluster_struct_attribute/jni/DemoClusterClient-InvokeSubscribeImpl.cpp
@@ -28,8 +28,12 @@ JNI_METHOD(jlong, DemoClusterCluster, initWithDevice)(JNIEnv * env, jobject self
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    DemoClusterCluster * cppCluster = new DemoClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+        DemoClusterCluster * cppCluster = new DemoClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 JNI_METHOD(void, DemoClusterCluster, subscribeArmFailsafesAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)

--- a/scripts/idl/tests/outputs/global_struct_attribute/jni/DemoClusterClient-InvokeSubscribeImpl.cpp
+++ b/scripts/idl/tests/outputs/global_struct_attribute/jni/DemoClusterClient-InvokeSubscribeImpl.cpp
@@ -28,8 +28,12 @@ JNI_METHOD(jlong, DemoClusterCluster, initWithDevice)(JNIEnv * env, jobject self
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    DemoClusterCluster * cppCluster = new DemoClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+        DemoClusterCluster * cppCluster = new DemoClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 JNI_METHOD(void, DemoClusterCluster, subscribeSomeLabelsAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)

--- a/scripts/idl/tests/outputs/optional_argument/jni/MyClusterClient-InvokeSubscribeImpl.cpp
+++ b/scripts/idl/tests/outputs/optional_argument/jni/MyClusterClient-InvokeSubscribeImpl.cpp
@@ -28,8 +28,12 @@ JNI_METHOD(jlong, MyClusterCluster, initWithDevice)(JNIEnv * env, jobject self, 
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    MyClusterCluster * cppCluster = new MyClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+        MyClusterCluster * cppCluster = new MyClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 JNI_METHOD(void, MyClusterCluster, 

--- a/scripts/idl/tests/outputs/several_clusters/jni/FirstClient-InvokeSubscribeImpl.cpp
+++ b/scripts/idl/tests/outputs/several_clusters/jni/FirstClient-InvokeSubscribeImpl.cpp
@@ -28,8 +28,12 @@ JNI_METHOD(jlong, FirstCluster, initWithDevice)(JNIEnv * env, jobject self, jlon
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    FirstCluster * cppCluster = new FirstCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+        FirstCluster * cppCluster = new FirstCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 JNI_METHOD(void, FirstCluster, subscribeSomeIntegerAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)

--- a/scripts/idl/tests/outputs/several_clusters/jni/SecondClient-InvokeSubscribeImpl.cpp
+++ b/scripts/idl/tests/outputs/several_clusters/jni/SecondClient-InvokeSubscribeImpl.cpp
@@ -28,8 +28,12 @@ JNI_METHOD(jlong, SecondCluster, initWithDevice)(JNIEnv * env, jobject self, jlo
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    SecondCluster * cppCluster = new SecondCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+        SecondCluster * cppCluster = new SecondCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 JNI_METHOD(void, SecondCluster, subscribeSomeBytesAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)

--- a/scripts/idl/tests/outputs/several_clusters/jni/ThirdClient-InvokeSubscribeImpl.cpp
+++ b/scripts/idl/tests/outputs/several_clusters/jni/ThirdClient-InvokeSubscribeImpl.cpp
@@ -28,8 +28,12 @@ JNI_METHOD(jlong, ThirdCluster, initWithDevice)(JNIEnv * env, jobject self, jlon
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    ThirdCluster * cppCluster = new ThirdCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+        ThirdCluster * cppCluster = new ThirdCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 JNI_METHOD(void, ThirdCluster, subscribeSomeEnumAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)

--- a/scripts/idl/tests/outputs/simple_attribute/jni/MyClusterClient-InvokeSubscribeImpl.cpp
+++ b/scripts/idl/tests/outputs/simple_attribute/jni/MyClusterClient-InvokeSubscribeImpl.cpp
@@ -28,8 +28,12 @@ JNI_METHOD(jlong, MyClusterCluster, initWithDevice)(JNIEnv * env, jobject self, 
 {
     chip::DeviceLayer::StackLock lock;
     DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    MyClusterCluster * cppCluster = new MyClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
-    return reinterpret_cast<jlong>(cppCluster);
+    if (device->GetSecureSession().HasValue())
+    {
+        MyClusterCluster * cppCluster = new MyClusterCluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), endpointId);
+        return reinterpret_cast<jlong>(cppCluster);
+    }
+    return reinterpret_cast<jlong>(nullptr);
 }
 
 JNI_METHOD(void, MyClusterCluster, subscribeClusterAttrAttribute)(JNIEnv * env, jobject self, jlong clusterPtr, jobject callback, jint minInterval, jint maxInterval)

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -52,6 +52,15 @@ void CASESessionManager::FindOrEstablishSession(PeerId peerId, Callback::Callbac
     }
 
     session->Connect(onConnection, onFailure);
+    // TODO this seems very hacky to me. Is there a better way????
+    // Up returning from Connect is it possible that `session` may have been released by the
+    // time Connect returns, so we need to get it again.
+    session = FindExistingSession(peerId);
+    if (session == nullptr)
+    {
+        // Connection has already been successfully established.
+        return;
+    }
     if (!session->IsConnected() && !session->IsConnecting() && !session->IsResolvingAddress())
     {
         // This session is not making progress toward anything.  It will have

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -52,25 +52,6 @@ void CASESessionManager::FindOrEstablishSession(PeerId peerId, Callback::Callbac
     }
 
     session->Connect(onConnection, onFailure);
-    // TODO this seems very hacky to me. Is there a better way????
-    // Up returning from Connect is it possible that `session` may have been released by the
-    // time Connect returns, so we need to get it again.
-    session = FindExistingSession(peerId);
-    if (session == nullptr)
-    {
-        // Connection has already been successfully established.
-        return;
-    }
-    if (!session->IsConnected() && !session->IsConnecting() && !session->IsResolvingAddress())
-    {
-        // This session is not making progress toward anything.  It will have
-        // notified the consumer about the failure already via the provided
-        // callbacks, if any.
-        //
-        // Release the peer rather than the pointer in case the failure handler
-        // has already released the session.
-        ReleaseSession(peerId);
-    }
 }
 
 void CASESessionManager::ReleaseSession(PeerId peerId)

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -39,7 +39,7 @@ void CASESessionManager::FindOrEstablishSession(PeerId peerId, Callback::Callbac
     {
         ChipLogDetail(CASESessionManager, "FindOrEstablishSession: No existing OperationalDeviceProxy instance found");
 
-        session = mConfig.devicePool->Allocate(mConfig.sessionInitParams, peerId);
+        session = mConfig.devicePool->Allocate(mConfig.sessionInitParams, peerId, this);
 
         if (session == nullptr)
         {

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -45,7 +45,7 @@ struct CASESessionManagerConfig
  * 4. During session establishment, trigger node ID resolution (if needed), and update the DNS-SD cache (if resolution is
  * successful)
  */
-class CASESessionManager
+class CASESessionManager : public OperationalReleaseDelegate
 {
 public:
     CASESessionManager() = default;
@@ -73,7 +73,7 @@ public:
 
     OperationalDeviceProxy * FindExistingSession(PeerId peerId) const;
 
-    void ReleaseSession(PeerId peerId);
+    void ReleaseSession(PeerId peerId) override;
 
     void ReleaseSessionsForFabric(FabricIndex fabricIndex);
 

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -270,6 +270,7 @@ void OperationalDeviceProxy::DequeueConnectionCallbacks(CHIP_ERROR error)
         }
     }
 
+    FoobarDeviceProxy foobar = FoobarDeviceProxy(mPeerId, GetExchangeManager(), mSecureSession);
     while (successReady.mNext != &successReady)
     {
         Callback::Callback<OnDeviceConnected> * cb = Callback::Callback<OnDeviceConnected>::FromCancelable(successReady.mNext);
@@ -277,7 +278,7 @@ void OperationalDeviceProxy::DequeueConnectionCallbacks(CHIP_ERROR error)
         cb->Cancel();
         if (error == CHIP_NO_ERROR)
         {
-            cb->mCall(cb->mContext, this);
+            cb->mCall(cb->mContext, foobar);
         }
     }
 }

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -282,7 +282,7 @@ void OperationalDeviceProxy::DequeueConnectionCallbacks(CHIP_ERROR error)
             // We know that we for sure have the SessionHandler in the successful case.
             VerifyOrDie(exchangeMgr);
             VerifyOrDie(sessionHandle.HasValue());
-            cb->mCall(cb->mContext, exchangeMgr, sessionHandle.Value());
+            cb->mCall(cb->mContext, *exchangeMgr, sessionHandle.Value());
         }
     }
 }

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -270,7 +270,8 @@ void OperationalDeviceProxy::DequeueConnectionCallbacks(CHIP_ERROR error)
         }
     }
 
-    FoobarDeviceProxy foobar = FoobarDeviceProxy(mPeerId, GetExchangeManager(), mSecureSession);
+    auto * exchangeMgr = GetExchangeManager();
+    auto sessionHandle = mSecureSession.Get();
     while (successReady.mNext != &successReady)
     {
         Callback::Callback<OnDeviceConnected> * cb = Callback::Callback<OnDeviceConnected>::FromCancelable(successReady.mNext);
@@ -278,7 +279,10 @@ void OperationalDeviceProxy::DequeueConnectionCallbacks(CHIP_ERROR error)
         cb->Cancel();
         if (error == CHIP_NO_ERROR)
         {
-            cb->mCall(cb->mContext, foobar);
+            // We know that we for sure have the SessionHandler in the successful case.
+            VerifyOrDie(exchangeMgr);
+            VerifyOrDie(sessionHandle.HasValue());
+            cb->mCall(cb->mContext, exchangeMgr, sessionHandle.Value());
         }
     }
 }

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -297,7 +297,11 @@ void OperationalDeviceProxy::DequeueConnectionCallbacks(CHIP_ERROR error)
         }
     }
 
-    releaseDelegate->ReleaseSession(peerId);
+    // TODO can I do a verify or die on this in the constructor to know it is
+    // for sure valid?
+    if (releaseDelegate) {
+        releaseDelegate->ReleaseSession(peerId);
+    }
 }
 
 void OperationalDeviceProxy::OnSessionEstablishmentError(CHIP_ERROR error)

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -72,7 +72,29 @@ struct DeviceProxyInitParams
 
 class OperationalDeviceProxy;
 
-typedef void (*OnDeviceConnected)(void * context, OperationalDeviceProxy * device);
+class FoobarDeviceProxy : public DeviceProxy {
+public:
+    FoobarDeviceProxy(const PeerId & peerId, Messaging::ExchangeManager * exchangeMgr, SessionHolder sessionHolder) :
+        mPeerId(peerId),
+        mExchangeMgr(exchangeMgr),
+        mSecureSession(sessionHolder) {}
+    FoobarDeviceProxy() {}
+    void ShutdownSubscriptions() override { VerifyOrDie(false); }  // Currently not implemented.
+    void Disconnect() override { mSecureSession.Release(); }
+    Messaging::ExchangeManager * GetExchangeManager() const override { return mExchangeMgr; }
+    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.Get(); }
+    NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
+    PeerId GetPeerId() const { return mPeerId; }
+
+private:
+    bool IsSecureConnected() const override { return static_cast<bool>(mSecureSession); }
+
+    PeerId mPeerId;
+    Messaging::ExchangeManager * mExchangeMgr = nullptr;
+    SessionHolder mSecureSession;
+};
+
+typedef void (*OnDeviceConnected)(void * context, FoobarDeviceProxy device);
 typedef void (*OnDeviceConnectionFailure)(void * context, PeerId peerId, CHIP_ERROR error);
 
 /**

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -99,13 +99,19 @@ public:
     void ShutdownSubscriptions() override { VerifyOrDie(false); } // Currently not implemented.
     void Disconnect() override
     {
-        // TODO should I be cleaning up mExchangeMgr, and mPeerScopedNodeId.
         mSecureSession.Release();
+        mExchangeMgr = nullptr;
+        mPeerScopedNodeId = ScopedNodeId();
     }
     Messaging::ExchangeManager * GetExchangeManager() const override { return mExchangeMgr; }
     chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.Get(); }
     NodeId GetDeviceId() const override { return mPeerScopedNodeId.GetNodeId(); }
     ScopedNodeId GetPeerScopedNodeId() const { return mPeerScopedNodeId; }
+
+    bool ConnectionReady() const
+    {
+        return (mExchangeMgr != nullptr && IsSecureConnected());
+    }
 
 private:
     bool IsSecureConnected() const override { return static_cast<bool>(mSecureSession); }

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -73,13 +73,16 @@ struct DeviceProxyInitParams
 class OperationalDeviceProxy;
 
 /**
- * @brief Helper function as applications refactor away from holding onto a device proxy.
+ * @brief Minimal implementation of DeviceProxy that encapsulates a SessionHolder to track a CASE session.
  *
  * Deprecated - Avoid using this object.
  *
- * This is an object that is meant to only be used by application that previously incorrectly held onto
- * OperationDeviceProxy in previous implementations of OnDeviceConnected. It is expected that over time
- * all instances of DeviceProxySession will be refactored out of existence.
+ * DeviceProxySession is a minimal implementation of DeviceProxy. It is meant to provide a transition
+ * for existing consumers of OperationalDeviceProxy that were delivered a reference to that object in
+ * their respective OnDeviceConnected callback, but were incorrectly holding onto that object pass
+ * the function call. DeviceProxySession can be held on for as long as is desired, while still
+ * minimizing the code changes needed to transition to a more final solution by virtue of
+ * implementing DeviceProxy.
  */
 class DeviceProxySession : public DeviceProxy
 {
@@ -115,7 +118,7 @@ private:
  * application code does incorrectly held onto this information so do not follow those incorrect
  * implementations as an example.
  */
-typedef void (*OnDeviceConnected)(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+typedef void (*OnDeviceConnected)(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
 typedef void (*OnDeviceConnectionFailure)(void * context, PeerId peerId, CHIP_ERROR error);
 
 /**

--- a/src/app/OperationalDeviceProxyPool.h
+++ b/src/app/OperationalDeviceProxyPool.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <app/CASESessionManager.h>
 #include <app/OperationalDeviceProxy.h>
 #include <lib/support/Pool.h>
 #include <transport/SessionHandle.h>
@@ -26,7 +27,7 @@ namespace chip {
 class OperationalDeviceProxyPoolDelegate
 {
 public:
-    virtual OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, PeerId peerId) = 0;
+    virtual OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, PeerId peerId, OperationalReleaseDelegate * releaseDelegate) = 0;
 
     virtual void Release(OperationalDeviceProxy * device) = 0;
 
@@ -45,9 +46,9 @@ class OperationalDeviceProxyPool : public OperationalDeviceProxyPoolDelegate
 public:
     ~OperationalDeviceProxyPool() override { mDevicePool.ReleaseAll(); }
 
-    OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, PeerId peerId) override
+    OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, PeerId peerId, OperationalReleaseDelegate * releaseDelegate) override
     {
-        return mDevicePool.CreateObject(params, peerId);
+        return mDevicePool.CreateObject(params, peerId, releaseDelegate);
     }
 
     void Release(OperationalDeviceProxy * device) override { mDevicePool.ReleaseObject(device); }

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -406,20 +406,20 @@ constexpr ClusterId kClusterIdAudioOutput     = 0x050b;
 // constexpr ClusterId kClusterIdApplicationLauncher = 0x050c;
 // constexpr ClusterId kClusterIdAccountLogin        = 0x050e;
 
-CHIP_ERROR ContentAppPlatform::ManageClientAccess(OperationalDeviceProxy * targetDeviceProxy, uint16_t targetVendorId,
-                                                  NodeId localNodeId, Controller::WriteResponseSuccessCallback successCb,
+CHIP_ERROR ContentAppPlatform::ManageClientAccess(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle,
+                                                  uint16_t targetVendorId, NodeId localNodeId,
+                                                  Controller::WriteResponseSuccessCallback successCb,
                                                   Controller::WriteResponseFailureCallback failureCb)
 {
-    VerifyOrReturnError(targetDeviceProxy != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(successCb != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(failureCb != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     Access::AccessControl::Entry entry;
     ReturnErrorOnFailure(GetAccessControl().PrepareEntry(entry));
     ReturnErrorOnFailure(entry.SetAuthMode(Access::AuthMode::kCase));
-    entry.SetFabricIndex(targetDeviceProxy->GetFabricIndex());
+    entry.SetFabricIndex(sessionHandle->GetFabricIndex());
     ReturnErrorOnFailure(entry.SetPrivilege(Access::Privilege::kOperate));
-    ReturnErrorOnFailure(entry.AddSubject(nullptr, targetDeviceProxy->GetDeviceId()));
+    ReturnErrorOnFailure(entry.AddSubject(nullptr, sessionHandle->GetPeer().GetNodeId()));
 
     std::vector<Binding::Structs::TargetStruct::Type> bindings;
 
@@ -507,13 +507,12 @@ CHIP_ERROR ContentAppPlatform::ManageClientAccess(OperationalDeviceProxy * targe
     }
 
     // TODO: add a subject description on the ACL
-    ReturnErrorOnFailure(GetAccessControl().CreateEntry(nullptr, targetDeviceProxy->GetFabricIndex(), nullptr, entry));
+    ReturnErrorOnFailure(GetAccessControl().CreateEntry(nullptr, sessionHandle->GetFabricIndex(), nullptr, entry));
 
     ChipLogProgress(Controller, "Attempting to update Binding list");
     BindingListType bindingList(bindings.data(), bindings.size());
 
-    chip::Controller::BindingCluster cluster(*targetDeviceProxy->GetExchangeManager(),
-                                             targetDeviceProxy->GetSecureSession().Value(), kTargetBindingClusterEndpointId);
+    chip::Controller::BindingCluster cluster(exchangeMgr, sessionHandle, kTargetBindingClusterEndpointId);
 
     ReturnErrorOnFailure(
         cluster.WriteAttribute<Binding::Attributes::Binding::TypeInfo>(bindingList, nullptr, successCb, failureCb));

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -124,11 +124,12 @@ public:
      *   Add ACLs on this device for the given client,
      *   and create bindings on the given client so that it knows what it has access to.
      *
-     * @param[in] targetDeviceProxy  OperationalDeviceProxy for the target device.
-     * @param[in] targetVendorId     Vendor ID for the target device.
-     * @param[in] localNodeId        The NodeId for the local device.
-     * @param[in] successCb          The function to be called on success of adding the binding.
-     * @param[in] failureCb          The function to be called on failure of adding the binding.
+     * @param[in] exchangeMgr     Exchange manager to be used to get an exchange context.
+     * @param[in] sessionHandle   Reference to an established session.
+     * @param[in] targetVendorId  Vendor ID for the target device.
+     * @param[in] localNodeId     The NodeId for the local device.
+     * @param[in] successCb       The function to be called on success of adding the binding.
+     * @param[in] failureCb       The function to be called on failure of adding the binding.
      *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -132,8 +132,8 @@ public:
      *
      * @return CHIP_ERROR         CHIP_NO_ERROR on success, or corresponding error
      */
-    CHIP_ERROR ManageClientAccess(OperationalDeviceProxy * targetDeviceProxy, uint16_t targetVendorId, NodeId localNodeId,
-                                  Controller::WriteResponseSuccessCallback successCb,
+    CHIP_ERROR ManageClientAccess(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle, uint16_t targetVendorId,
+                                  NodeId localNodeId, Controller::WriteResponseSuccessCallback successCb,
                                   Controller::WriteResponseFailureCallback failureCb);
 
 protected:

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -144,13 +144,13 @@ CHIP_ERROR BindingManager::EstablishConnection(FabricIndex fabric, NodeId node)
     return mLastSessionEstablishmentError;
 }
 
-void BindingManager::HandleDeviceConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+void BindingManager::HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     BindingManager * manager = static_cast<BindingManager *>(context);
     manager->HandleDeviceConnected(exchangeMgr, sessionHandle);
 }
 
-void BindingManager::HandleDeviceConnected(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+void BindingManager::HandleDeviceConnected(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     FabricIndex fabricToRemove = kUndefinedFabricIndex;
     NodeId nodeToRemove        = kUndefinedNodeId;
@@ -166,7 +166,7 @@ void BindingManager::HandleDeviceConnected(Messaging::ExchangeManager * exchange
         {
             fabricToRemove = entry.fabricIndex;
             nodeToRemove   = entry.nodeId;
-            mBoundDeviceChangedHandler(entry, exchangeMgr, &sessionHandle, pendingNotification.mContext->GetContext());
+            mBoundDeviceChangedHandler(entry, &exchangeMgr, &sessionHandle, pendingNotification.mContext->GetContext());
         }
     }
     mPendingNotificationMap.RemoveAllEntriesForNode(fabricToRemove, nodeToRemove);

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -62,7 +62,11 @@ chip::PeerId PeerIdForNode(chip::FabricTable * fabricTable, chip::FabricIndex fa
 
 chip::ScopedNodeId ScopedNodeIdForNode(chip::FabricTable * fabricTable, chip::FabricIndex fabric, chip::NodeId node)
 {
-    const chip::FabricInfo * fabricInfo = fabricTable->FindFabricWithIndex(fabric);
+    if (fabricTable == nullptr)
+    {
+        return chip::ScopedNodeId();
+    }
+    auto * fabricInfo = fabricTable->FindFabricWithIndex(fabric);
     if (fabricInfo == nullptr)
     {
         return chip::ScopedNodeId();

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -170,7 +170,8 @@ void BindingManager::HandleDeviceConnected(Messaging::ExchangeManager & exchange
         {
             fabricToRemove = entry.fabricIndex;
             nodeToRemove   = entry.nodeId;
-            mBoundDeviceChangedHandler(entry, &exchangeMgr, &sessionHandle, pendingNotification.mContext->GetContext());
+            DeviceProxySession device(&exchangeMgr, sessionHandle);
+            mBoundDeviceChangedHandler(entry, &device, pendingNotification.mContext->GetContext());
         }
     }
     mPendingNotificationMap.RemoveAllEntriesForNode(fabricToRemove, nodeToRemove);
@@ -222,7 +223,7 @@ CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, Cluste
             }
             else if (iter->type == EMBER_MULTICAST_BINDING)
             {
-                mBoundDeviceChangedHandler(*iter, nullptr, nullptr, bindingContext->GetContext());
+                mBoundDeviceChangedHandler(*iter, nullptr, bindingContext->GetContext());
             }
         }
     }

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -37,8 +37,10 @@ namespace chip {
  *
  * E.g. The application will send on/off commands to peer for the OnOff cluster.
  *
+ * The handler is not allowed to hold onto the pointer to the SessionHandler that is passed in.
  */
-using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device, void * context);
+using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
+                                           SessionHandle * sessionHandle, void * context);
 
 /**
  * Application callback function when a context used in NotifyBoundClusterChanged will not be needed and should be
@@ -123,8 +125,8 @@ public:
 private:
     static BindingManager sBindingManager;
 
-    static void HandleDeviceConnected(void * context, FoobarDeviceProxy device);
-    void HandleDeviceConnected(FoobarDeviceProxy & device);
+    static void HandleDeviceConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    void HandleDeviceConnected(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
 
     static void HandleDeviceConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
     void HandleDeviceConnectionFailure(PeerId peerId, CHIP_ERROR error);

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -125,8 +125,8 @@ public:
 private:
     static BindingManager sBindingManager;
 
-    static void HandleDeviceConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
-    void HandleDeviceConnected(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    static void HandleDeviceConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
+    void HandleDeviceConnected(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
 
     static void HandleDeviceConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
     void HandleDeviceConnectionFailure(PeerId peerId, CHIP_ERROR error);

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -38,7 +38,7 @@ namespace chip {
  * E.g. The application will send on/off commands to peer for the OnOff cluster.
  *
  */
-using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, DeviceProxy * peer_device, void * context);
+using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, FoobarDeviceProxy * peer_device, void * context);
 
 /**
  * Application callback function when a context used in NotifyBoundClusterChanged will not be needed and should be
@@ -123,8 +123,8 @@ public:
 private:
     static BindingManager sBindingManager;
 
-    static void HandleDeviceConnected(void * context, OperationalDeviceProxy * device);
-    void HandleDeviceConnected(OperationalDeviceProxy * device);
+    static void HandleDeviceConnected(void * context, FoobarDeviceProxy device);
+    void HandleDeviceConnected(FoobarDeviceProxy & device);
 
     static void HandleDeviceConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
     void HandleDeviceConnectionFailure(PeerId peerId, CHIP_ERROR error);

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -39,8 +39,8 @@ namespace chip {
  *
  * The handler is not allowed to hold onto the pointer to the SessionHandler that is passed in.
  */
-using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, Messaging::ExchangeManager * exchangeMgr,
-                                           SessionHandle * sessionHandle, void * context);
+using BoundDeviceChangedHandler = void (*)(const EmberBindingTableEntry & binding, DeviceProxySession * device,
+                                           void * context);
 
 /**
  * Application callback function when a context used in NotifyBoundClusterChanged will not be needed and should be

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -431,16 +431,15 @@ CHIP_ERROR DefaultOTARequestor::GetUpdateStateAttribute(EndpointId endpointId, O
 }
 
 // Called whenever FindOrEstablishSession is successful
-void DefaultOTARequestor::OnConnected(void * context, OperationalDeviceProxy * deviceProxy)
+void DefaultOTARequestor::OnConnected(void * context, FoobarDeviceProxy deviceProxy)
 {
     DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
-    VerifyOrDie(deviceProxy != nullptr);
 
     switch (requestorCore->mOnConnectedAction)
     {
     case kQueryImage: {
-        CHIP_ERROR err = requestorCore->SendQueryImageRequest(*deviceProxy);
+        CHIP_ERROR err = requestorCore->SendQueryImageRequest(deviceProxy);
 
         if (err != CHIP_NO_ERROR)
         {
@@ -451,7 +450,7 @@ void DefaultOTARequestor::OnConnected(void * context, OperationalDeviceProxy * d
         break;
     }
     case kDownload: {
-        CHIP_ERROR err = requestorCore->StartDownload(*deviceProxy);
+        CHIP_ERROR err = requestorCore->StartDownload(deviceProxy);
 
         if (err != CHIP_NO_ERROR)
         {
@@ -462,7 +461,7 @@ void DefaultOTARequestor::OnConnected(void * context, OperationalDeviceProxy * d
         break;
     }
     case kApplyUpdate: {
-        CHIP_ERROR err = requestorCore->SendApplyUpdateRequest(*deviceProxy);
+        CHIP_ERROR err = requestorCore->SendApplyUpdateRequest(deviceProxy);
 
         if (err != CHIP_NO_ERROR)
         {
@@ -473,7 +472,7 @@ void DefaultOTARequestor::OnConnected(void * context, OperationalDeviceProxy * d
         break;
     }
     case kNotifyUpdateApplied: {
-        CHIP_ERROR err = requestorCore->SendNotifyUpdateAppliedRequest(*deviceProxy);
+        CHIP_ERROR err = requestorCore->SendNotifyUpdateAppliedRequest(deviceProxy);
 
         if (err != CHIP_NO_ERROR)
         {
@@ -739,7 +738,7 @@ CHIP_ERROR DefaultOTARequestor::GenerateUpdateToken()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(FoobarDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -807,7 +806,7 @@ CHIP_ERROR DefaultOTARequestor::ExtractUpdateDescription(const QueryImageRespons
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DefaultOTARequestor::StartDownload(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::StartDownload(FoobarDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mBdxDownloader != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -846,7 +845,7 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(OperationalDeviceProxy & devicePro
     return err;
 }
 
-CHIP_ERROR DefaultOTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::SendApplyUpdateRequest(FoobarDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
@@ -861,7 +860,7 @@ CHIP_ERROR DefaultOTARequestor::SendApplyUpdateRequest(OperationalDeviceProxy & 
     return cluster.InvokeCommand(args, this, OnApplyUpdateResponse, OnApplyUpdateFailure);
 }
 
-CHIP_ERROR DefaultOTARequestor::SendNotifyUpdateAppliedRequest(OperationalDeviceProxy & deviceProxy)
+CHIP_ERROR DefaultOTARequestor::SendNotifyUpdateAppliedRequest(FoobarDeviceProxy & deviceProxy)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -431,7 +431,7 @@ CHIP_ERROR DefaultOTARequestor::GetUpdateStateAttribute(EndpointId endpointId, O
 }
 
 // Called whenever FindOrEstablishSession is successful
-void DefaultOTARequestor::OnConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+void DefaultOTARequestor::OnConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
@@ -738,7 +738,7 @@ CHIP_ERROR DefaultOTARequestor::GenerateUpdateToken()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
@@ -774,7 +774,7 @@ CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(Messaging::ExchangeManager
         args.location.SetValue(CharSpan("XX", strlen("XX")));
     }
 
-    Controller::OtaSoftwareUpdateProviderCluster cluster(*exchangeMgr, sessionHandle, mProviderLocation.Value().endpoint);
+    Controller::OtaSoftwareUpdateProviderCluster cluster(exchangeMgr, sessionHandle, mProviderLocation.Value().endpoint);
 
     return cluster.InvokeCommand(args, this, OnQueryImageResponse, OnQueryImageFailure);
 }
@@ -805,7 +805,7 @@ CHIP_ERROR DefaultOTARequestor::ExtractUpdateDescription(const QueryImageRespons
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     VerifyOrReturnError(mBdxDownloader != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -817,7 +817,7 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager * excha
     initOptions.FileDesLength    = static_cast<uint16_t>(mFileDesignator.size());
     initOptions.FileDesignator   = reinterpret_cast<const uint8_t *>(mFileDesignator.data());
 
-    chip::Messaging::ExchangeContext * exchangeCtx = exchangeMgr->NewContext(sessionHandle, &mBdxMessenger);
+    chip::Messaging::ExchangeContext * exchangeCtx = exchangeMgr.NewContext(sessionHandle, &mBdxMessenger);
     VerifyOrReturnError(exchangeCtx != nullptr, CHIP_ERROR_NO_MEMORY);
 
     mBdxMessenger.Init(mBdxDownloader, exchangeCtx);
@@ -838,7 +838,7 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(Messaging::ExchangeManager * excha
     return err;
 }
 
-CHIP_ERROR DefaultOTARequestor::SendApplyUpdateRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+CHIP_ERROR DefaultOTARequestor::SendApplyUpdateRequest(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
     ReturnErrorOnFailure(GenerateUpdateToken());
@@ -847,12 +847,12 @@ CHIP_ERROR DefaultOTARequestor::SendApplyUpdateRequest(Messaging::ExchangeManage
     args.updateToken = mUpdateToken;
     args.newVersion  = mTargetVersion;
 
-    Controller::OtaSoftwareUpdateProviderCluster cluster(*exchangeMgr, sessionHandle, mProviderLocation.Value().endpoint);
+    Controller::OtaSoftwareUpdateProviderCluster cluster(exchangeMgr, sessionHandle, mProviderLocation.Value().endpoint);
 
     return cluster.InvokeCommand(args, this, OnApplyUpdateResponse, OnApplyUpdateFailure);
 }
 
-CHIP_ERROR DefaultOTARequestor::SendNotifyUpdateAppliedRequest(Messaging::ExchangeManager * exchangeMgr,
+CHIP_ERROR DefaultOTARequestor::SendNotifyUpdateAppliedRequest(Messaging::ExchangeManager & exchangeMgr,
                                                                SessionHandle & sessionHandle)
 {
     VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
@@ -862,7 +862,7 @@ CHIP_ERROR DefaultOTARequestor::SendNotifyUpdateAppliedRequest(Messaging::Exchan
     args.updateToken     = mUpdateToken;
     args.softwareVersion = mCurrentVersion;
 
-    Controller::OtaSoftwareUpdateProviderCluster cluster(*exchangeMgr, sessionHandle, mProviderLocation.Value().endpoint);
+    Controller::OtaSoftwareUpdateProviderCluster cluster(exchangeMgr, sessionHandle, mProviderLocation.Value().endpoint);
 
     // There is no response for a notify so consider this OTA complete. Clear the provider location and reset any states to indicate
     // so.

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -223,7 +223,7 @@ private:
     /**
      * Send QueryImage request using values matching Basic cluster
      */
-    CHIP_ERROR SendQueryImageRequest(OperationalDeviceProxy & deviceProxy);
+    CHIP_ERROR SendQueryImageRequest(FoobarDeviceProxy & deviceProxy);
 
     /**
      * Validate and extract mandatory information from QueryImageResponse
@@ -254,17 +254,17 @@ private:
     /**
      * Start download of the software image returned in QueryImageResponse
      */
-    CHIP_ERROR StartDownload(OperationalDeviceProxy & deviceProxy);
+    CHIP_ERROR StartDownload(FoobarDeviceProxy & deviceProxy);
 
     /**
      * Send ApplyUpdate request using values obtained from QueryImageResponse
      */
-    CHIP_ERROR SendApplyUpdateRequest(OperationalDeviceProxy & deviceProxy);
+    CHIP_ERROR SendApplyUpdateRequest(FoobarDeviceProxy & deviceProxy);
 
     /**
      * Send NotifyUpdateApplied request
      */
-    CHIP_ERROR SendNotifyUpdateAppliedRequest(OperationalDeviceProxy & deviceProxy);
+    CHIP_ERROR SendNotifyUpdateAppliedRequest(FoobarDeviceProxy & deviceProxy);
 
     /**
      * Store current update information to KVS
@@ -279,7 +279,7 @@ private:
     /**
      * Session connection callbacks
      */
-    static void OnConnected(void * context, OperationalDeviceProxy * deviceProxy);
+    static void OnConnected(void * context, FoobarDeviceProxy deviceProxy);
     static void OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
     Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -223,7 +223,7 @@ private:
     /**
      * Send QueryImage request using values matching Basic cluster
      */
-    CHIP_ERROR SendQueryImageRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    CHIP_ERROR SendQueryImageRequest(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Validate and extract mandatory information from QueryImageResponse
@@ -254,17 +254,17 @@ private:
     /**
      * Start download of the software image returned in QueryImageResponse
      */
-    CHIP_ERROR StartDownload(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    CHIP_ERROR StartDownload(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Send ApplyUpdate request using values obtained from QueryImageResponse
      */
-    CHIP_ERROR SendApplyUpdateRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    CHIP_ERROR SendApplyUpdateRequest(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Send NotifyUpdateApplied request
      */
-    CHIP_ERROR SendNotifyUpdateAppliedRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    CHIP_ERROR SendNotifyUpdateAppliedRequest(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Store current update information to KVS
@@ -279,7 +279,7 @@ private:
     /**
      * Session connection callbacks
      */
-    static void OnConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    static void OnConnected(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
     static void OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
     Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -223,7 +223,7 @@ private:
     /**
      * Send QueryImage request using values matching Basic cluster
      */
-    CHIP_ERROR SendQueryImageRequest(FoobarDeviceProxy & deviceProxy);
+    CHIP_ERROR SendQueryImageRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Validate and extract mandatory information from QueryImageResponse
@@ -254,17 +254,17 @@ private:
     /**
      * Start download of the software image returned in QueryImageResponse
      */
-    CHIP_ERROR StartDownload(FoobarDeviceProxy & deviceProxy);
+    CHIP_ERROR StartDownload(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Send ApplyUpdate request using values obtained from QueryImageResponse
      */
-    CHIP_ERROR SendApplyUpdateRequest(FoobarDeviceProxy & deviceProxy);
+    CHIP_ERROR SendApplyUpdateRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Send NotifyUpdateApplied request
      */
-    CHIP_ERROR SendNotifyUpdateAppliedRequest(FoobarDeviceProxy & deviceProxy);
+    CHIP_ERROR SendNotifyUpdateAppliedRequest(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
 
     /**
      * Store current update information to KVS
@@ -279,7 +279,7 @@ private:
     /**
      * Session connection callbacks
      */
-    static void OnConnected(void * context, FoobarDeviceProxy deviceProxy);
+    static void OnConnected(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
     static void OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
     Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;

--- a/src/app/tests/TestOperationalDeviceProxy.cpp
+++ b/src/app/tests/TestOperationalDeviceProxy.cpp
@@ -39,6 +39,11 @@ namespace {
 
 using TestTransportMgr = TransportMgr<Transport::UDP>;
 
+class SessionReleaser : public OperationalReleaseDelegate {
+public:
+    void ReleaseSession(PeerId peerId) override {}
+};
+
 void TestOperationalDeviceProxy_EstablishSessionDirectly(nlTestSuite * inSuite, void * inContext)
 {
     // TODO: This test appears not to be workable since it does not init the fabric table!!!
@@ -57,6 +62,7 @@ void TestOperationalDeviceProxy_EstablishSessionDirectly(nlTestSuite * inSuite, 
     secure_channel::MessageCounterManager messageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;
     GroupDataProviderImpl groupDataProvider;
+    SessionReleaser sessionRelease;
 
     systemLayer.Init();
     udpEndPointManager.Init(systemLayer);
@@ -77,7 +83,7 @@ void TestOperationalDeviceProxy_EstablishSessionDirectly(nlTestSuite * inSuite, 
         .groupDataProvider        = &groupDataProvider,
     };
     NodeId mockNodeId = 1;
-    OperationalDeviceProxy device(params, PeerId().SetNodeId(mockNodeId));
+    OperationalDeviceProxy device(params, PeerId().SetNodeId(mockNodeId), sessionRelease);
     Inet::IPAddress mockAddr;
     Inet::IPAddress::FromString("127.0.0.1", mockAddr);
     PeerAddress addr = PeerAddress::UDP(mockAddr, CHIP_PORT);

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -63,7 +63,7 @@ private:
 
     DeviceCommissioner * mCommissioner                               = nullptr;
     CommissioneeDeviceProxy * mCommissioneeDeviceProxy               = nullptr;
-    FoobarDeviceProxy * mOperationalDeviceProxy                      = nullptr;
+    DeviceProxySession * mOperationalDeviceProxy                     = nullptr;
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate = nullptr;
     CommissioningParameters mParams                                  = CommissioningParameters();
     // Memory space for the commisisoning parameters that come in as ByteSpans - the caller is not guaranteed to retain this memory

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -63,7 +63,7 @@ private:
 
     DeviceCommissioner * mCommissioner                               = nullptr;
     CommissioneeDeviceProxy * mCommissioneeDeviceProxy               = nullptr;
-    OperationalDeviceProxy * mOperationalDeviceProxy                 = nullptr;
+    FoobarDeviceProxy * mOperationalDeviceProxy                      = nullptr;
     OperationalCredentialsDelegate * mOperationalCredentialsDelegate = nullptr;
     CommissioningParameters mParams                                  = CommissioningParameters();
     // Memory space for the commisisoning parameters that come in as ByteSpans - the caller is not guaranteed to retain this memory

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1592,7 +1592,7 @@ void DeviceCommissioner::CommissioningStageComplete(CHIP_ERROR err, Commissionin
 // for and maintain this value appropriatly.
 DeviceProxySession foobar;
 
-void DeviceCommissioner::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager * exchangeMgr,
+void DeviceCommissioner::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr,
                                              SessionHandle & sessionHandle)
 {
     // CASE session established.
@@ -1615,7 +1615,7 @@ void DeviceCommissioner::OnDeviceConnectedFn(void * context, Messaging::Exchange
 
     if (commissioner->mCommissioningDelegate != nullptr)
     {
-        foobar = DeviceProxySession(exchangeMgr, sessionHandle);
+        foobar = DeviceProxySession(&exchangeMgr, sessionHandle);
         CommissioningDelegate::CommissioningReport report;
         report.Set<OperationalNodeFoundData>(OperationalNodeFoundData(&foobar));
         commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1588,7 +1588,9 @@ void DeviceCommissioner::CommissioningStageComplete(CHIP_ERROR err, Commissionin
     }
 }
 
-void DeviceCommissioner::OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device)
+FoobarDeviceProxy foobar;
+
+void DeviceCommissioner::OnDeviceConnectedFn(void * context, FoobarDeviceProxy device)
 {
     // CASE session established.
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
@@ -1602,7 +1604,7 @@ void DeviceCommissioner::OnDeviceConnectedFn(void * context, OperationalDevicePr
     }
 
     if (commissioner->mDeviceBeingCommissioned == nullptr ||
-        commissioner->mDeviceBeingCommissioned->GetDeviceId() != device->GetDeviceId())
+        commissioner->mDeviceBeingCommissioned->GetDeviceId() != device.GetDeviceId())
     {
         // Not the device we are trying to commission.
         return;
@@ -1610,8 +1612,9 @@ void DeviceCommissioner::OnDeviceConnectedFn(void * context, OperationalDevicePr
 
     if (commissioner->mCommissioningDelegate != nullptr)
     {
+        foobar = device;
         CommissioningDelegate::CommissioningReport report;
-        report.Set<OperationalNodeFoundData>(OperationalNodeFoundData(device));
+        report.Set<OperationalNodeFoundData>(OperationalNodeFoundData(&foobar));
         commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
     }
 }

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -751,7 +751,7 @@ private:
     /* Callback called when adding root cert to device results in failure */
     static void OnRootCertFailureResponse(void * context, CHIP_ERROR error);
 
-    static void OnDeviceConnectedFn(void * context, FoobarDeviceProxy device);
+    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     static void OnDeviceAttestationInformationVerification(void * context, Credentials::AttestationVerificationResult result);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -751,7 +751,7 @@ private:
     /* Callback called when adding root cert to device results in failure */
     static void OnRootCertFailureResponse(void * context, CHIP_ERROR error);
 
-    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     static void OnDeviceAttestationInformationVerification(void * context, Credentials::AttestationVerificationResult result);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -751,7 +751,7 @@ private:
     /* Callback called when adding root cert to device results in failure */
     static void OnRootCertFailureResponse(void * context, CHIP_ERROR error);
 
-    static void OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device);
+    static void OnDeviceConnectedFn(void * context, FoobarDeviceProxy device);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     static void OnDeviceAttestationInformationVerification(void * context, Credentials::AttestationVerificationResult result);

--- a/src/controller/CommissionerDiscoveryController.cpp
+++ b/src/controller/CommissionerDiscoveryController.cpp
@@ -178,7 +178,8 @@ void CommissionerDiscoveryController::Cancel()
 }
 
 void CommissionerDiscoveryController::CommissioningSucceeded(uint16_t vendorId, uint16_t productId, NodeId nodeId,
-                                                             OperationalDeviceProxy * device)
+                                                             Messaging::ExchangeManager & exchangeMgr,
+                                                             SessionHandle & sessionHandle)
 {
     mVendorId  = vendorId;
     mProductId = productId;
@@ -186,7 +187,7 @@ void CommissionerDiscoveryController::CommissioningSucceeded(uint16_t vendorId, 
     if (mPostCommissioningListener != nullptr)
     {
         ChipLogDetail(Controller, "CommissionerDiscoveryController calling listener");
-        mPostCommissioningListener->CommissioningCompleted(vendorId, productId, nodeId, device);
+        mPostCommissioningListener->CommissioningCompleted(vendorId, productId, nodeId, exchangeMgr, sessionHandle);
     }
     else
     {

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -133,10 +133,10 @@ public:
      *  @param[in]    vendorId           The vendorid from the DAC of the new node.
      *  @param[in]    productId          The productid from the DAC of the new node.
      *  @param[in]    nodeId             The node id for the newly commissioned node.
-     *  @param[in]    device             The device proxy for use in cluster communication.
+     *  @param[in]    exchangeMgr        The exchange manager to be used to get an exchange context.
+     *  @param[in]    sessionHandle      A reference to an established session.
      *
      */
-    // TODO update documentation above
     virtual void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId,
                                         chip::Messaging::ExchangeManager & exchangeMgr, chip::SessionHandle & sessionHandle) = 0;
 
@@ -212,10 +212,10 @@ public:
      *  @param[in]    vendorId           The vendorid from the DAC of the new node.
      *  @param[in]    productId          The productid from the DAC of the new node.
      *  @param[in]    nodeId             The node id for the newly commissioned node.
-     *  @param[in]    device             The device proxy for use in cluster communication.
+     *  @param[in]    exchangeMgr        The exchange manager to be used to get an exchange context.
+     *  @param[in]    sessionHandle      A reference to an established session.
      *
      */
-    // TODO update documentation above
     void CommissioningSucceeded(uint16_t vendorId, uint16_t productId, NodeId nodeId,
                                 chip::Messaging::ExchangeManager & exchangeMgr, chip::SessionHandle & sessionHandle);
 

--- a/src/controller/CommissionerDiscoveryController.h
+++ b/src/controller/CommissionerDiscoveryController.h
@@ -136,7 +136,9 @@ public:
      *  @param[in]    device             The device proxy for use in cluster communication.
      *
      */
-    virtual void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId, OperationalDeviceProxy * device) = 0;
+    // TODO update documentation above
+    virtual void CommissioningCompleted(uint16_t vendorId, uint16_t productId, NodeId nodeId,
+                                        chip::Messaging::ExchangeManager & exchangeMgr, chip::SessionHandle & sessionHandle) = 0;
 
     virtual ~PostCommissioningListener() = default;
 };
@@ -213,7 +215,9 @@ public:
      *  @param[in]    device             The device proxy for use in cluster communication.
      *
      */
-    void CommissioningSucceeded(uint16_t vendorId, uint16_t productId, NodeId nodeId, OperationalDeviceProxy * device);
+    // TODO update documentation above
+    void CommissioningSucceeded(uint16_t vendorId, uint16_t productId, NodeId nodeId,
+                                chip::Messaging::ExchangeManager & exchangeMgr, chip::SessionHandle & sessionHandle);
 
     /**
      * This method should be called by the commissioner to indicate that commissioning failed.

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -417,8 +417,8 @@ struct NocChain
 
 struct OperationalNodeFoundData
 {
-    OperationalNodeFoundData(FoobarDeviceProxy * proxy) : operationalProxy(proxy) {}
-    FoobarDeviceProxy * operationalProxy;
+    OperationalNodeFoundData(DeviceProxySession * proxy) : operationalProxy(proxy) {}
+    DeviceProxySession * operationalProxy;
 };
 
 struct NetworkClusterInfo

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -417,8 +417,8 @@ struct NocChain
 
 struct OperationalNodeFoundData
 {
-    OperationalNodeFoundData(OperationalDeviceProxy * proxy) : operationalProxy(proxy) {}
-    OperationalDeviceProxy * operationalProxy;
+    OperationalNodeFoundData(FoobarDeviceProxy * proxy) : operationalProxy(proxy) {}
+    FoobarDeviceProxy * operationalProxy;
 };
 
 struct NetworkClusterInfo

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -124,14 +124,14 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
     return mController->GetConnectedDevice(mNodeId, &mDeviceConnected, &mDeviceConnectionFailure);
 }
 
-CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(const FoobarDeviceProxy & device)
+CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(Messaging::ExchangeManager * exchangeMgr,
+                                                                      SessionHandle & sessionHandle)
 {
     ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, mNodeId);
 
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 
-    AdministratorCommissioningCluster cluster(*device.GetExchangeManager(), device.GetSecureSession().Value(),
-                                              kAdministratorCommissioningClusterEndpoint);
+    AdministratorCommissioningCluster cluster(*exchangeMgr, sessionHandle, kAdministratorCommissioningClusterEndpoint);
 
     if (mCommissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode)
     {
@@ -254,7 +254,8 @@ void CommissioningWindowOpener::OnOpenCommissioningWindowFailure(void * context,
     }
 }
 
-void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, FoobarDeviceProxy device)
+void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Messaging::ExchangeManager * exchangeMgr,
+                                                          SessionHandle & sessionHandle)
 {
     auto * self = static_cast<CommissioningWindowOpener *>(context);
 
@@ -267,7 +268,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Foobar
     {
     case Step::kReadVID: {
         constexpr EndpointId kBasicClusterEndpoint = 0;
-        BasicCluster cluster(*device.GetExchangeManager(), device.GetSecureSession().Value(), kBasicClusterEndpoint);
+        BasicCluster cluster(*exchangeMgr, sessionHandle, kBasicClusterEndpoint);
         err = cluster.ReadAttribute<app::Clusters::Basic::Attributes::VendorID::TypeInfo>(context, OnVIDReadResponse,
                                                                                           OnVIDPIDReadFailureResponse);
 #if CHIP_ERROR_LOGGING
@@ -277,7 +278,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Foobar
     }
     case Step::kReadPID: {
         constexpr EndpointId kBasicClusterEndpoint = 0;
-        BasicCluster cluster(*device.GetExchangeManager(), device.GetSecureSession().Value(), kBasicClusterEndpoint);
+        BasicCluster cluster(*exchangeMgr, sessionHandle, kBasicClusterEndpoint);
         err = cluster.ReadAttribute<app::Clusters::Basic::Attributes::ProductID::TypeInfo>(context, OnPIDReadResponse,
                                                                                            OnVIDPIDReadFailureResponse);
 #if CHIP_ERROR_LOGGING
@@ -286,7 +287,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Foobar
         break;
     }
     case Step::kOpenCommissioningWindow: {
-        err = self->OpenCommissioningWindowInternal(device);
+        err = self->OpenCommissioningWindowInternal(exchangeMgr, sessionHandle);
 #if CHIP_ERROR_LOGGING
         messageIfError = "Could not connect to open commissioning window";
 #endif // CHIP_ERROR_LOGGING

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -124,14 +124,14 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
     return mController->GetConnectedDevice(mNodeId, &mDeviceConnected, &mDeviceConnectionFailure);
 }
 
-CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(Messaging::ExchangeManager * exchangeMgr,
+CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(Messaging::ExchangeManager & exchangeMgr,
                                                                       SessionHandle & sessionHandle)
 {
     ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, mNodeId);
 
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 
-    AdministratorCommissioningCluster cluster(*exchangeMgr, sessionHandle, kAdministratorCommissioningClusterEndpoint);
+    AdministratorCommissioningCluster cluster(exchangeMgr, sessionHandle, kAdministratorCommissioningClusterEndpoint);
 
     if (mCommissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode)
     {
@@ -254,7 +254,7 @@ void CommissioningWindowOpener::OnOpenCommissioningWindowFailure(void * context,
     }
 }
 
-void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Messaging::ExchangeManager * exchangeMgr,
+void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Messaging::ExchangeManager & exchangeMgr,
                                                           SessionHandle & sessionHandle)
 {
     auto * self = static_cast<CommissioningWindowOpener *>(context);
@@ -268,7 +268,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Messag
     {
     case Step::kReadVID: {
         constexpr EndpointId kBasicClusterEndpoint = 0;
-        BasicCluster cluster(*exchangeMgr, sessionHandle, kBasicClusterEndpoint);
+        BasicCluster cluster(exchangeMgr, sessionHandle, kBasicClusterEndpoint);
         err = cluster.ReadAttribute<app::Clusters::Basic::Attributes::VendorID::TypeInfo>(context, OnVIDReadResponse,
                                                                                           OnVIDPIDReadFailureResponse);
 #if CHIP_ERROR_LOGGING
@@ -278,7 +278,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Messag
     }
     case Step::kReadPID: {
         constexpr EndpointId kBasicClusterEndpoint = 0;
-        BasicCluster cluster(*exchangeMgr, sessionHandle, kBasicClusterEndpoint);
+        BasicCluster cluster(exchangeMgr, sessionHandle, kBasicClusterEndpoint);
         err = cluster.ReadAttribute<app::Clusters::Basic::Attributes::ProductID::TypeInfo>(context, OnPIDReadResponse,
                                                                                            OnVIDPIDReadFailureResponse);
 #if CHIP_ERROR_LOGGING

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -124,13 +124,13 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
     return mController->GetConnectedDevice(mNodeId, &mDeviceConnected, &mDeviceConnectionFailure);
 }
 
-CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(OperationalDeviceProxy * device)
+CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(const FoobarDeviceProxy & device)
 {
     ChipLogProgress(Controller, "OpenCommissioningWindow for device ID %" PRIu64, mNodeId);
 
     constexpr EndpointId kAdministratorCommissioningClusterEndpoint = 0;
 
-    AdministratorCommissioningCluster cluster(*device->GetExchangeManager(), device->GetSecureSession().Value(),
+    AdministratorCommissioningCluster cluster(*device.GetExchangeManager(), device.GetSecureSession().Value(),
                                               kAdministratorCommissioningClusterEndpoint);
 
     if (mCommissioningWindowOption != CommissioningWindowOption::kOriginalSetupCode)
@@ -254,7 +254,7 @@ void CommissioningWindowOpener::OnOpenCommissioningWindowFailure(void * context,
     }
 }
 
-void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, OperationalDeviceProxy * device)
+void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, FoobarDeviceProxy device)
 {
     auto * self = static_cast<CommissioningWindowOpener *>(context);
 
@@ -267,7 +267,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Operat
     {
     case Step::kReadVID: {
         constexpr EndpointId kBasicClusterEndpoint = 0;
-        BasicCluster cluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), kBasicClusterEndpoint);
+        BasicCluster cluster(*device.GetExchangeManager(), device.GetSecureSession().Value(), kBasicClusterEndpoint);
         err = cluster.ReadAttribute<app::Clusters::Basic::Attributes::VendorID::TypeInfo>(context, OnVIDReadResponse,
                                                                                           OnVIDPIDReadFailureResponse);
 #if CHIP_ERROR_LOGGING
@@ -277,7 +277,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Operat
     }
     case Step::kReadPID: {
         constexpr EndpointId kBasicClusterEndpoint = 0;
-        BasicCluster cluster(*device->GetExchangeManager(), device->GetSecureSession().Value(), kBasicClusterEndpoint);
+        BasicCluster cluster(*device.GetExchangeManager(), device.GetSecureSession().Value(), kBasicClusterEndpoint);
         err = cluster.ReadAttribute<app::Clusters::Basic::Attributes::ProductID::TypeInfo>(context, OnPIDReadResponse,
                                                                                            OnVIDPIDReadFailureResponse);
 #if CHIP_ERROR_LOGGING

--- a/src/controller/CommissioningWindowOpener.h
+++ b/src/controller/CommissioningWindowOpener.h
@@ -120,13 +120,13 @@ private:
         kOpenCommissioningWindow,
     };
 
-    CHIP_ERROR OpenCommissioningWindowInternal(OperationalDeviceProxy * device);
+    CHIP_ERROR OpenCommissioningWindowInternal(const FoobarDeviceProxy & device);
     static void OnPIDReadResponse(void * context, uint16_t value);
     static void OnVIDReadResponse(void * context, VendorId value);
     static void OnVIDPIDReadFailureResponse(void * context, CHIP_ERROR error);
     static void OnOpenCommissioningWindowSuccess(void * context, const app::DataModel::NullObjectType &);
     static void OnOpenCommissioningWindowFailure(void * context, CHIP_ERROR error);
-    static void OnDeviceConnectedCallback(void * context, OperationalDeviceProxy * device);
+    static void OnDeviceConnectedCallback(void * context, FoobarDeviceProxy device);
     static void OnDeviceConnectionFailureCallback(void * context, PeerId peerId, CHIP_ERROR error);
 
     DeviceController * const mController = nullptr;

--- a/src/controller/CommissioningWindowOpener.h
+++ b/src/controller/CommissioningWindowOpener.h
@@ -120,13 +120,13 @@ private:
         kOpenCommissioningWindow,
     };
 
-    CHIP_ERROR OpenCommissioningWindowInternal(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    CHIP_ERROR OpenCommissioningWindowInternal(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
     static void OnPIDReadResponse(void * context, uint16_t value);
     static void OnVIDReadResponse(void * context, VendorId value);
     static void OnVIDPIDReadFailureResponse(void * context, CHIP_ERROR error);
     static void OnOpenCommissioningWindowSuccess(void * context, const app::DataModel::NullObjectType &);
     static void OnOpenCommissioningWindowFailure(void * context, CHIP_ERROR error);
-    static void OnDeviceConnectedCallback(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
+    static void OnDeviceConnectedCallback(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureCallback(void * context, PeerId peerId, CHIP_ERROR error);
 
     DeviceController * const mController = nullptr;

--- a/src/controller/CommissioningWindowOpener.h
+++ b/src/controller/CommissioningWindowOpener.h
@@ -120,13 +120,13 @@ private:
         kOpenCommissioningWindow,
     };
 
-    CHIP_ERROR OpenCommissioningWindowInternal(const FoobarDeviceProxy & device);
+    CHIP_ERROR OpenCommissioningWindowInternal(Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
     static void OnPIDReadResponse(void * context, uint16_t value);
     static void OnVIDReadResponse(void * context, VendorId value);
     static void OnVIDPIDReadFailureResponse(void * context, CHIP_ERROR error);
     static void OnOpenCommissioningWindowSuccess(void * context, const app::DataModel::NullObjectType &);
     static void OnOpenCommissioningWindowFailure(void * context, CHIP_ERROR error);
-    static void OnDeviceConnectedCallback(void * context, FoobarDeviceProxy device);
+    static void OnDeviceConnectedCallback(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureCallback(void * context, PeerId peerId, CHIP_ERROR error);
 
     DeviceController * const mController = nullptr;

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -84,7 +84,7 @@ void GetConnectedDeviceCallback::OnDeviceConnectedFn(void * context, Messaging::
     // connected callback lives only in the cpp side and we use the SessionHandle immediately for what we intend.
     //
     // TODO I don't think we can actually do new here, figure out the proper way to alloc this.
-    DeviceProxySession * device = new DeviceProxySession(exchangeMgr, sessionHandle);
+    DeviceProxySession * device = new DeviceProxySession(&exchangeMgr, sessionHandle);
     DeviceLayer::StackUnlock unlock;
     env->CallVoidMethod(javaCallback, successMethod, reinterpret_cast<jlong>(device));
 }

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -57,7 +57,7 @@ GetConnectedDeviceCallback::~GetConnectedDeviceCallback()
     env->DeleteGlobalRef(mJavaCallbackRef);
 }
 
-void GetConnectedDeviceCallback::OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device)
+void GetConnectedDeviceCallback::OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
 {
     JNIEnv * env         = JniReferences::GetInstance().GetEnvForCurrentThread();
     auto * self          = static_cast<GetConnectedDeviceCallback *>(context);
@@ -78,6 +78,13 @@ void GetConnectedDeviceCallback::OnDeviceConnectedFn(void * context, Operational
     VerifyOrReturn(successMethod != nullptr, ChipLogError(Controller, "Could not find onDeviceConnected method"));
 
     static_assert(sizeof(jlong) >= sizeof(void *), "Need to store a pointer in a Java handle");
+
+    // TODO (#) This is a memory leak since as of today this is never freed. Either we need to make sure this is free
+    // after the java side is done with this pointer, or we need to refactor how this is used so that the the on
+    // connected callback lives only in the cpp side and we use the SessionHandle immediately for what we intend.
+    //
+    // TODO I don't think we can actually do new here, figure out the proper way to alloc this.
+    DeviceProxySession * device = new DeviceProxySession(exchangeMgr, sessionHandle);
     DeviceLayer::StackUnlock unlock;
     env->CallVoidMethod(javaCallback, successMethod, reinterpret_cast<jlong>(device));
 }

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -33,7 +33,7 @@ struct GetConnectedDeviceCallback
     GetConnectedDeviceCallback(jobject wrapperCallback, jobject javaCallback);
     ~GetConnectedDeviceCallback();
 
-    static void OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device);
+    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
 
     Callback::Callback<OnDeviceConnected> mOnSuccess;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -619,10 +619,10 @@ struct GetDeviceCallbacks
         mOnSuccess(OnDeviceConnectedFn, this), mOnFailure(OnConnectionFailureFn, this), mCallback(callback)
     {}
 
-    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
+    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle)
     {
         auto * self = static_cast<GetDeviceCallbacks *>(context);
-        foobar      = DeviceProxySession(exchangeMgr, sessionHandle);
+        foobar      = DeviceProxySession(&exchangeMgr, sessionHandle);
         // TODO TMsg: this is a hack, this makes it so that we cannot perform parallel task.
         self->mCallback(&foobar, CHIP_NO_ERROR.AsInteger());
         delete self;

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -608,16 +608,21 @@ const char * pychip_Stack_StatusReportToString(uint32_t profileId, uint16_t stat
 }
 
 namespace {
+
+FoobarDeviceProxy foobar;
+
 struct GetDeviceCallbacks
 {
     GetDeviceCallbacks(DeviceAvailableFunc callback) :
         mOnSuccess(OnDeviceConnectedFn, this), mOnFailure(OnConnectionFailureFn, this), mCallback(callback)
     {}
 
-    static void OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device)
+    static void OnDeviceConnectedFn(void * context, FoobarDeviceProxy device)
     {
         auto * self = static_cast<GetDeviceCallbacks *>(context);
-        self->mCallback(device, CHIP_NO_ERROR.AsInteger());
+        foobar = device;
+        // TODO TMsg: this is a hack, this makes it so that we cannot perform parallel task.
+        self->mCallback(&foobar, CHIP_NO_ERROR.AsInteger());
         delete self;
     }
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -609,7 +609,9 @@ const char * pychip_Stack_StatusReportToString(uint32_t profileId, uint16_t stat
 
 namespace {
 
-FoobarDeviceProxy foobar;
+// TODO This is a hack right now. I will need to figure out where this should
+// actually live, the lifetime of it and be sure it is cleaned up properly.
+DeviceProxySession foobar;
 
 struct GetDeviceCallbacks
 {
@@ -617,10 +619,10 @@ struct GetDeviceCallbacks
         mOnSuccess(OnDeviceConnectedFn, this), mOnFailure(OnConnectionFailureFn, this), mCallback(callback)
     {}
 
-    static void OnDeviceConnectedFn(void * context, FoobarDeviceProxy device)
+    static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager * exchangeMgr, SessionHandle & sessionHandle)
     {
         auto * self = static_cast<GetDeviceCallbacks *>(context);
-        foobar = device;
+        foobar      = DeviceProxySession(exchangeMgr, sessionHandle);
         // TODO TMsg: this is a hack, this makes it so that we cannot perform parallel task.
         self->mCallback(&foobar, CHIP_NO_ERROR.AsInteger());
         delete self;


### PR DESCRIPTION
Why is this change happening:
* Previous usage of OnDeviceConnected when a clients held onto OperationalDeviceProxy it could lead to use after free should something else free that OperationalDeviceProxy.
* New API makes it more clear that the SessionHandle is intended to be consumed in the callback itself.
* Since many current application incorrectly implemented OnDeviceConnected, we have provided a helper as an interim solution since this is already a large refactor I didn't want to decouple the work of them . We are hoping in the future refactor in sections of code using DeviceProxySession will move towards a more proper implementation.