### PR TITLE
Fix/efr32 ci with pw roll up

### DIFF
--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -112,7 +112,10 @@ silabs_executable("efr32_device_tests") {
 
   inputs = [ ldscript ]
 
-  ldflags = [ "-T" + rebase_path(ldscript, root_build_dir) ]
+  ldflags = [
+    "-T" + rebase_path(ldscript, root_build_dir),
+    "-Wl,--no-warn-rwx-segment",
+  ]
 
   output_dir = root_out_dir
 }

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -72,6 +72,7 @@ silabs_executable("efr32_device_tests") {
     "${chip_root}/examples/common/pigweed/efr32/PigweedLoggerMutex.cpp",
     "${examples_common_plat_dir}/PigweedLogger.cpp",
     "${examples_common_plat_dir}/heap_4_silabs.c",
+    "${examples_common_plat_dir}/syscalls_stubs.cpp",
     "${examples_plat_dir}/init_efrPlatform.cpp",
     "${examples_plat_dir}/uart.cpp",
     "src/main.cpp",

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -505,6 +505,9 @@ template("efr32_sdk") {
 
       # see https://github.com/project-chip/connectedhomeip/issues/26058
       "-Wno-error=array-parameter",
+
+      # see https://github.com/project-chip/connectedhomeip/issues/26170
+      "-Wno-error=array-bounds",
     ]
 
     if (silabs_family == "efr32mg24" || silabs_family == "mgm24") {


### PR DESCRIPTION
Fix efr32 test-diver app by adding the syscalls_stubs to the build and disabling the warn rwx segment for the linker

Fix efr32 lighting pigweed-rpc app when is_debug=false by disabling flag for an error found in GSDK. (will be fixed in next gsdk release)